### PR TITLE
Shrink name struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ libc = "0.2"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-smallvec = "1.7"
+smallvec = { features = ["union"], version = "1.9" }
 smallstr = "0.2"
 
 [dev-dependencies]

--- a/src/comparison.rs
+++ b/src/comparison.rs
@@ -2,7 +2,7 @@ use super::nickname::have_matching_variants;
 use super::utils::*;
 use super::{Name, WordIndices, Words};
 use std::borrow::Cow;
-use std::iter::{Enumerate, Peekable};
+use std::iter::Enumerate;
 use std::ops::Range;
 use std::str::Chars;
 use unicode_segmentation::UnicodeSegmentation;
@@ -104,7 +104,7 @@ impl Name {
         GivenNamesOrInitials {
             initials: self.initials.chars().enumerate(),
             known_names: self.given_iter(),
-            known_name_indices: self.word_indices_in_initials.clone().peekable(),
+            known_name_indices: self.word_indices_in_initials.clone(),
         }
     }
 
@@ -490,7 +490,7 @@ impl<'a> NameWordOrInitial<'a> {
 struct GivenNamesOrInitials<'a> {
     initials: Enumerate<Chars<'a>>,
     known_names: Words<'a>,
-    known_name_indices: Peekable<WordIndices>,
+    known_name_indices: WordIndices,
 }
 
 #[derive(Debug)]
@@ -506,7 +506,7 @@ impl<'a> Iterator for GivenNamesOrInitials<'a> {
         self.initials
             .next()
             .map(|(i, initial)| match self.known_name_indices.peek() {
-                Some(&Range { start, end }) if start == i => {
+                Some(Range { start, end }) if start == i => {
                     self.known_name_indices.next();
 
                     // Handle case of hyphenated name for which we have 2+ initials

--- a/src/comparison.rs
+++ b/src/comparison.rs
@@ -1,10 +1,9 @@
 use super::nickname::have_matching_variants;
 use super::utils::*;
-use super::{Name, Words};
+use super::{Name, WordIndices, Words};
 use std::borrow::Cow;
 use std::iter::{Enumerate, Peekable};
 use std::ops::Range;
-use std::slice::Iter;
 use std::str::Chars;
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -105,7 +104,7 @@ impl Name {
         GivenNamesOrInitials {
             initials: self.initials.chars().enumerate(),
             known_names: self.given_iter(),
-            known_name_indices: self.word_indices_in_initials.iter().peekable(),
+            known_name_indices: self.word_indices_in_initials.clone().peekable(),
         }
     }
 
@@ -276,7 +275,7 @@ impl Name {
 
         let mut prev = 0;
 
-        for &Range { start, end } in self.word_indices_in_initials.iter() {
+        for Range { start, end } in self.word_indices_in_initials.clone() {
             if start > prev {
                 return true;
             } else {
@@ -491,7 +490,7 @@ impl<'a> NameWordOrInitial<'a> {
 struct GivenNamesOrInitials<'a> {
     initials: Enumerate<Chars<'a>>,
     known_names: Words<'a>,
-    known_name_indices: Peekable<Iter<'a, Range<usize>>>,
+    known_name_indices: Peekable<WordIndices>,
 }
 
 #[derive(Debug)]
@@ -507,7 +506,7 @@ impl<'a> Iterator for GivenNamesOrInitials<'a> {
         self.initials
             .next()
             .map(|(i, initial)| match self.known_name_indices.peek() {
-                Some(&&Range { start, end }) if start == i => {
+                Some(&Range { start, end }) if start == i => {
                     self.known_name_indices.next();
 
                     // Handle case of hyphenated name for which we have 2+ initials

--- a/src/external.rs
+++ b/src/external.rs
@@ -31,7 +31,7 @@ macro_rules! option_str_to_char_star {
 #[no_mangle]
 pub unsafe extern "C" fn human_name_parse(input: *const libc::c_char) -> Option<Box<Name>> {
     let s = CStr::from_ptr(input).to_string_lossy();
-    Name::parse(&*s).map(Box::new)
+    Name::parse(&s).map(Box::new)
 }
 
 #[no_mangle]
@@ -90,7 +90,7 @@ pub unsafe extern "C" fn human_name_matches_slug_or_localpart(
     input: *const libc::c_char,
 ) -> bool {
     let s = CStr::from_ptr(input).to_string_lossy();
-    name.matches_slug_or_localpart(&*s)
+    name.matches_slug_or_localpart(&s)
 }
 
 #[no_mangle]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,7 +278,7 @@ impl Name {
     /// assert!(name.goes_by_middle_name());
     /// ```
     pub fn goes_by_middle_name(&self) -> bool {
-        if let Some(Range { start, .. }) = self.word_indices_in_initials.get(0) {
+        if let Some(Range { start, .. }) = self.word_indices_in_initials.peek() {
             start > 0
         } else {
             false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -537,6 +537,12 @@ mod tests {
     #[cfg(feature = "bench")]
     use test::{black_box, Bencher};
 
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    #[test]
+    fn struct_size() {
+        assert_eq!(184, std::mem::size_of::<Name>());
+    }
+
     #[test]
     fn fast_path_parse_does_not_allocate() {
         deny_alloc(|| Name::parse("Jane Doe").unwrap());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ mod suffix;
 mod surname;
 mod title;
 mod web_match;
+mod word;
 
 pub mod external;
 
@@ -52,8 +53,8 @@ use std::borrow::Cow;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::ops::Range;
-use std::slice::Iter;
 use utils::{lowercase_if_alpha, normalize_nfkd_whitespace, transliterate};
+use word::{WordIndices, Words};
 
 #[cfg(test)]
 use alloc_counter::AllocCounterSystem;
@@ -86,11 +87,11 @@ pub const MAX_SEGMENTS: usize = parse::MAX_WORDS;
 #[derive(Clone, Debug)]
 pub struct Name {
     text: SmallString<[u8; 36]>,
-    word_indices_in_text: SmallVec<[Range<usize>; 5]>,
+    word_indices_in_text: WordIndices,
     surname_index: usize,
     generation_from_suffix: Option<u8>,
     initials: SmallString<[u8; 8]>,
-    word_indices_in_initials: SmallVec<[Range<usize>; 3]>,
+    word_indices_in_initials: WordIndices,
     pub hash: u64,
 }
 
@@ -186,8 +187,8 @@ impl Name {
         let mut initials = SmallString::with_capacity(surname_index);
 
         let mut surname_index_in_names = surname_index;
-        let mut word_indices_in_initials = SmallVec::with_capacity(surname_index);
-        let mut word_indices_in_text = SmallVec::with_capacity(words.len());
+        let mut word_indices_in_initials = WordIndices::new();
+        let mut word_indices_in_text = WordIndices::new();
 
         for (i, word) in words.iter().enumerate() {
             if word.is_initials() && i < surname_index {
@@ -227,9 +228,9 @@ impl Name {
         debug_assert!(!initials.is_empty(), "Initials are empty!");
 
         text.shrink_to_fit();
-        word_indices_in_text.shrink_to_fit();
+        // word_indices_in_text.shrink_to_fit();
         initials.shrink_to_fit();
-        word_indices_in_initials.shrink_to_fit();
+        // word_indices_in_initials.shrink_to_fit();
 
         Name {
             text,
@@ -277,10 +278,11 @@ impl Name {
     /// assert!(name.goes_by_middle_name());
     /// ```
     pub fn goes_by_middle_name(&self) -> bool {
-        self.word_indices_in_initials
-            .iter()
-            .take(1)
-            .any(|r| r.start > 0)
+        if let Some(Range { start, .. }) = self.word_indices_in_initials.get(0) {
+            start > 0
+        } else {
+            false
+        }
     }
 
     /// First and middle initials as a string (always present)
@@ -365,8 +367,13 @@ impl Name {
     /// assert_eq!("de la MacDonald", name.surname());
     /// ```
     pub fn surname(&self) -> &str {
-        let start = self.word_indices_in_text[self.surname_index].start;
-        let end = self.word_indices_in_text.last().unwrap().end;
+        let mut surname_indices = self
+            .word_indices_in_text
+            .clone()
+            .skip(self.surname_index)
+            .peekable();
+        let start = surname_indices.peek().unwrap().start;
+        let end = surname_indices.last().unwrap().end;
         &self.text[start..end]
     }
 
@@ -518,48 +525,9 @@ impl Name {
 
     #[inline]
     fn word_iter(&self, range: Range<usize>) -> Words {
-        Words {
-            text: &self.text,
-            indices: self.word_indices_in_text[range].iter(),
-        }
+        Words::new(&self.text, &self.word_indices_in_text, range)
     }
 }
-
-struct Words<'a> {
-    text: &'a str,
-    indices: Iter<'a, Range<usize>>,
-}
-
-impl<'a> Words<'a> {
-    pub fn join(mut self) -> Cow<'a, str> {
-        match self.len() {
-            0 => Cow::Borrowed(""),
-            1 => Cow::Borrowed(self.next().unwrap()),
-            _ => Cow::Owned(self.collect::<SmallVec<[&str; 5]>>().join(" ")),
-        }
-    }
-}
-
-impl<'a> Iterator for Words<'a> {
-    type Item = &'a str;
-    fn next(&mut self) -> Option<&'a str> {
-        self.indices.next().map(|range| &self.text[range.clone()])
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.indices.size_hint()
-    }
-}
-
-impl<'a> DoubleEndedIterator for Words<'a> {
-    fn next_back(&mut self) -> Option<&'a str> {
-        self.indices
-            .next_back()
-            .map(|range| &self.text[range.clone()])
-    }
-}
-
-impl<'a> ExactSizeIterator for Words<'a> {}
 
 #[cfg(test)]
 mod tests {

--- a/src/nickname.rs
+++ b/src/nickname.rs
@@ -173,8 +173,8 @@ pub fn have_matching_variants(original_a: &str, original_b: &str) -> bool {
     let original_a = to_ascii(original_a);
     let original_b = to_ascii(original_b);
 
-    let a_variants = NameVariants::for_name(&*original_a);
-    let b_variants = NameVariants::for_name(&*original_b);
+    let a_variants = NameVariants::for_name(&original_a);
+    let b_variants = NameVariants::for_name(&original_b);
 
     a_variants.iter_with_original().any(|a| {
         b_variants

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -64,7 +64,7 @@ impl<'a> Iterator for Segments<'a> {
         }
 
         // Now look for the next whitespace that remains
-        let next_whitespace = self.text.find(' ').unwrap_or_else(|| self.text.len());
+        let next_whitespace = self.text.find(' ').unwrap_or(self.text.len());
         let next_inner_period = self.text[0..next_whitespace].find('.');
         let next_boundary = match next_inner_period {
             Some(i) => i + 1,

--- a/src/suffix.rs
+++ b/src/suffix.rs
@@ -75,7 +75,7 @@ static SUFFIX_BY_GENERATION: [&str; 5] = ["Sr.", "Jr.", "III", "IV", "V"];
 pub fn generation_from_suffix(part: &NamePart, might_be_initials: bool) -> Option<u8> {
     match part.category {
         Category::Name(ref namecased) => {
-            let namecased: &str = &*namecased;
+            let namecased: &str = namecased;
             GENERATION_BY_SUFFIX.get(namecased).cloned()
         }
         Category::Abbreviation => {

--- a/src/surname.rs
+++ b/src/surname.rs
@@ -97,7 +97,7 @@ pub fn find_surname_index(words: &[NamePart]) -> usize {
 
     for (i, word) in words[0..words.len() - 1].iter().enumerate() {
         let key: &str = match word.category {
-            Category::Name(ref namecased) => &*namecased,
+            Category::Name(ref namecased) => namecased,
             _ => word.word,
         };
         if SURNAME_PREFIXES.contains(key) {

--- a/src/title.rs
+++ b/src/title.rs
@@ -411,7 +411,7 @@ fn might_be_title_part(word: &NamePart) -> bool {
     } else {
         match &word.category {
             Category::Name(ref namecased) => {
-                let namecased: &str = &*namecased;
+                let namecased: &str = namecased;
                 PREFIX_TITLE_PARTS.contains(namecased) || namecased.chars().any(char::is_numeric)
             }
             _ => true,
@@ -454,7 +454,7 @@ fn is_prefix_title(words: &[NamePart]) -> bool {
 fn is_postfix_title(word: &NamePart, might_be_initials: bool) -> bool {
     match word.category {
         Category::Name(ref namecased) => {
-            let namecased: &str = &*namecased;
+            let namecased: &str = namecased;
             POSTFIX_TITLES.contains(namecased) || namecased.chars().any(char::is_numeric)
         }
         Category::Initials => !might_be_initials && word.counts.alpha > 1,
@@ -491,7 +491,7 @@ pub fn find_postfix_index(words: &[NamePart], expect_initials: bool) -> usize {
     let first_abbr_index = words
         .iter()
         .position(|word| !word.is_namelike() && !word.is_initials())
-        .unwrap_or_else(|| words.len());
+        .unwrap_or(words.len());
 
     cmp::min(
         first_abbr_index,

--- a/src/title.rs
+++ b/src/title.rs
@@ -445,9 +445,7 @@ fn is_prefix_title(words: &[NamePart]) -> bool {
     }
 
     if words.len() > 1 {
-        words[0..words.len() - 1]
-            .iter()
-            .all(might_be_title_part)
+        words[0..words.len() - 1].iter().all(might_be_title_part)
     } else {
         true
     }

--- a/src/word.rs
+++ b/src/word.rs
@@ -1,0 +1,151 @@
+use std::borrow::Cow;
+use std::collections::VecDeque;
+use std::convert::TryInto;
+use std::ops::Range;
+
+pub struct Words<'a> {
+    text: &'a str,
+    indices: WordIndices,
+}
+
+impl<'a> Words<'a> {
+    pub fn new(text: &'a str, indices: &WordIndices, range: Range<usize>) -> Words<'a> {
+        let mut indices = indices.clone();
+
+        for _ in 0..range.start {
+            indices.next();
+        }
+        while indices.len() > range.len() {
+            indices.next_back();
+        }
+
+        Words { text, indices }
+    }
+
+    pub fn join(mut self) -> Cow<'a, str> {
+        match self.len() {
+            0 => Cow::Borrowed(""),
+            1 => Cow::Borrowed(self.next().unwrap()),
+            _ => Cow::Owned(self.collect::<Vec<_>>().join(" ")),
+        }
+    }
+}
+
+impl<'a> Iterator for Words<'a> {
+    type Item = &'a str;
+    fn next(&mut self) -> Option<&'a str> {
+        self.indices.next().map(|i| &self.text[i])
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.indices.size_hint()
+    }
+}
+
+impl<'a> DoubleEndedIterator for Words<'a> {
+    fn next_back(&mut self) -> Option<&'a str> {
+        self.indices.next_back().map(|i| &self.text[i])
+    }
+}
+
+impl<'a> ExactSizeIterator for Words<'a> {}
+
+#[derive(Clone, Debug)]
+pub enum WordIndices {
+    Short { starts: u64, ends: u64 },
+    Unbounded(VecDeque<Range<usize>>),
+}
+
+impl WordIndices {
+    pub fn new() -> Self {
+        WordIndices::Short { starts: 0, ends: 0 }
+    }
+
+    pub fn push(&mut self, indices: Range<usize>) {
+        match self {
+            WordIndices::Unbounded(data) => {
+                data.push_back(indices);
+            }
+            WordIndices::Short { starts, ends } => {
+                if indices.end >= 64 {
+                    let mut unbounded = WordIndices::Unbounded(self.collect());
+                    unbounded.push(indices);
+                    let _ = std::mem::replace(self, unbounded);
+                } else {
+                    *starts |= 1 << indices.start;
+                    *ends |= 1 << indices.end;
+                }
+            }
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            WordIndices::Unbounded(data) => data.len(),
+            WordIndices::Short { starts, .. } => starts.count_ones().try_into().unwrap(),
+        }
+    }
+
+    pub fn get(&self, i: usize) -> Option<Range<usize>> {
+        match self {
+            WordIndices::Unbounded(data) => data.get(i).cloned(),
+            WordIndices::Short { .. } => self.clone().nth(i),
+        }
+    }
+}
+
+impl Iterator for WordIndices {
+    type Item = Range<usize>;
+
+    fn next(&mut self) -> Option<Range<usize>> {
+        match self {
+            WordIndices::Unbounded(data) => data.pop_front(),
+            WordIndices::Short { starts, ends } => {
+                if *starts == 0 {
+                    return None;
+                }
+                assert!(*ends > 0);
+
+                let start = starts.trailing_zeros();
+                let end = ends.trailing_zeros();
+
+                *starts ^= 1 << start;
+                *ends ^= 1 << end;
+
+                Some(start.try_into().unwrap()..end.try_into().unwrap())
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let size = match self {
+            WordIndices::Unbounded(data) => data.len(),
+            WordIndices::Short { starts, .. } => starts.count_ones().try_into().unwrap(),
+        };
+        (size, Some(size))
+    }
+}
+
+impl DoubleEndedIterator for WordIndices {
+    fn next_back(&mut self) -> Option<Range<usize>> {
+        match self {
+            WordIndices::Unbounded(data) => data.pop_back(),
+            WordIndices::Short { starts, ends } => {
+                if *starts == 0 {
+                    return None;
+                }
+                assert!(*ends > 0);
+
+                let start = 63 - starts.leading_zeros();
+                let end = 63 - ends.leading_zeros();
+
+                *starts ^= 1 << start;
+                *ends ^= 1 << end;
+
+                Some(start.try_into().unwrap()..end.try_into().unwrap())
+            }
+        }
+    }
+}
+
+impl ExactSizeIterator for WordIndices {}

--- a/src/word.rs
+++ b/src/word.rs
@@ -1,166 +1,86 @@
 use std::borrow::Cow;
-use std::collections::VecDeque;
 use std::convert::TryInto;
-use std::num::NonZeroU64;
-use std::ops::Range;
+use std::iter::Peekable;
+use std::ops::{Deref, Range};
+use std::slice;
+use SmallVec;
 
 pub struct Words<'a> {
     text: &'a str,
-    indices: WordIndices,
+    indices: Peekable<slice::Iter<'a, Range<u16>>>,
 }
 
 impl<'a> Words<'a> {
-    pub fn new(text: &'a str, indices: &WordIndices, range: Range<usize>) -> Words<'a> {
-        let mut indices = indices.clone();
-
-        for _ in 0..range.start {
-            indices.next();
+    #[inline]
+    pub fn new(text: &'a str, indices: &'a [Range<u16>]) -> Words<'a> {
+        Words {
+            text,
+            indices: indices.iter().peekable(),
         }
-        while indices.len() > range.len() {
-            indices.next_back();
-        }
-
-        Words { text, indices }
     }
 
     pub fn join(mut self) -> Cow<'a, str> {
         match self.len() {
             0 => Cow::Borrowed(""),
             1 => Cow::Borrowed(self.next().unwrap()),
-            _ => Cow::Owned(self.collect::<Vec<_>>().join(" ")),
+            _ => Cow::Owned(self.collect::<SmallVec<[&str; 4]>>().join(" ")),
         }
     }
 }
 
 impl<'a> Iterator for Words<'a> {
     type Item = &'a str;
+
+    #[inline]
     fn next(&mut self) -> Option<&'a str> {
-        self.indices.next().map(|i| &self.text[i])
+        self.indices
+            .next()
+            .map(|&Range { start, end }| &self.text[start.into()..end.into()])
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.indices.size_hint()
     }
 }
 
 impl<'a> DoubleEndedIterator for Words<'a> {
+    #[inline]
     fn next_back(&mut self) -> Option<&'a str> {
-        self.indices.next_back().map(|i| &self.text[i])
+        self.indices
+            .next_back()
+            .map(|&Range { start, end }| &self.text[start.into()..end.into()])
     }
 }
 
 impl<'a> ExactSizeIterator for Words<'a> {}
 
 #[derive(Clone, Debug)]
-pub enum WordIndices {
-    Short { starts: u64, ends: u64 },
-    Unbounded(VecDeque<Range<usize>>),
-}
+pub struct WordIndices(SmallVec<[Range<u16>; 4]>);
 
 impl WordIndices {
+    #[inline]
     pub fn new() -> Self {
-        WordIndices::Short { starts: 0, ends: 0 }
+        WordIndices(SmallVec::new())
     }
 
+    #[inline]
     pub fn push(&mut self, indices: Range<usize>) {
-        match self {
-            WordIndices::Unbounded(data) => {
-                data.push_back(indices);
-            }
-            WordIndices::Short { starts, ends } => {
-                if indices.end >= 64 {
-                    let mut unbounded = WordIndices::Unbounded(self.collect());
-                    unbounded.push(indices);
-                    let _ = std::mem::replace(self, unbounded);
-                } else {
-                    *starts |= 1 << indices.start;
-                    *ends |= 1 << indices.end;
-                }
-            }
-        }
+        self.0
+            .push(indices.start.try_into().unwrap()..indices.end.try_into().unwrap())
     }
 
-    pub fn len(&self) -> usize {
-        match self {
-            WordIndices::Unbounded(data) => data.len(),
-            WordIndices::Short { starts, .. } => starts.count_ones().try_into().unwrap(),
-        }
-    }
-
-    pub fn peek(&self) -> Option<Range<usize>> {
-        match self {
-            WordIndices::Unbounded(data) => data.front().cloned(),
-            WordIndices::Short { starts, ends } => {
-                none_if_empty(*starts, *ends).map(|(starts, ends)| {
-                    let start = starts.trailing_zeros();
-                    let end = ends.trailing_zeros();
-
-                    start.try_into().unwrap()..end.try_into().unwrap()
-                })
-            }
-        }
+    #[inline]
+    pub fn shrink_to_fit(&mut self) {
+        self.0.shrink_to_fit();
     }
 }
 
-#[inline]
-fn none_if_empty(starts: u64, ends: u64) -> Option<(NonZeroU64, NonZeroU64)> {
-    debug_assert!(starts.count_ones() == ends.count_ones());
+impl Deref for WordIndices {
+    type Target = [Range<u16>];
 
-    if let Some(starts) = NonZeroU64::new(starts) {
-        if let Some(ends) = NonZeroU64::new(ends) {
-            return Some((starts, ends));
-        }
-    }
-
-    None
-}
-
-impl Iterator for WordIndices {
-    type Item = Range<usize>;
-
-    fn next(&mut self) -> Option<Range<usize>> {
-        match self {
-            WordIndices::Unbounded(data) => data.pop_front(),
-            WordIndices::Short { starts, ends } => {
-                none_if_empty(*starts, *ends).map(|(nonempty_starts, nonempty_ends)| {
-                    let start = nonempty_starts.trailing_zeros();
-                    let end = nonempty_ends.trailing_zeros();
-
-                    *starts ^= 1 << start;
-                    *ends ^= 1 << end;
-
-                    start.try_into().unwrap()..end.try_into().unwrap()
-                })
-            }
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let size = match self {
-            WordIndices::Unbounded(data) => data.len(),
-            WordIndices::Short { starts, .. } => starts.count_ones().try_into().unwrap(),
-        };
-        (size, Some(size))
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
-
-impl DoubleEndedIterator for WordIndices {
-    fn next_back(&mut self) -> Option<Range<usize>> {
-        match self {
-            WordIndices::Unbounded(data) => data.pop_back(),
-            WordIndices::Short { starts, ends } => {
-                none_if_empty(*starts, *ends).map(|(nonempty_starts, nonempty_ends)| {
-                    let start = 63 - nonempty_starts.leading_zeros();
-                    let end = 63 - nonempty_ends.leading_zeros();
-
-                    *starts ^= 1 << start;
-                    *ends ^= 1 << end;
-
-                    start.try_into().unwrap()..end.try_into().unwrap()
-                })
-            }
-        }
-    }
-}
-
-impl ExactSizeIterator for WordIndices {}

--- a/src/word.rs
+++ b/src/word.rs
@@ -7,6 +7,11 @@ use SmallVec;
 
 pub struct Words<'a> {
     text: &'a str,
+
+    // Storing as u16 is sufficient because MAX_NAME_LEN is 1024.
+    //
+    // We could compress a bit further (especially given that the common case is much shorter)
+    // but it's not obviously worth the code complexity.
     indices: Peekable<slice::Iter<'a, Range<u16>>>,
 }
 


### PR DESCRIPTION
Shrink from 284 bytes on x86 to 144, by switching storage of indices to u16 

Also get recently added clippy lints passing