### PR TITLE
Preserve honorifics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "human_name"
-version = "1.0.5"
+version = "1.1.0"
 dependencies = [
  "alloc_counter",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "human_name"
-version = "1.0.5"
+version = "1.1.0"
 authors = ["David Judd <david.a.judd@gmail.com>"]
 description = "A library for parsing and comparing human names"
 keywords = ["human", "name", "language", "nlp"]

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ let oscar = Name::parse("MR OSCAR DE LA HOYA JR").unwrap();
 assert_eq!(Some("Oscar"), oscar.given_name());
 assert_eq!("de la Hoya", oscar.surname());
 assert_eq!(Some("Jr."), oscar.generational_suffix());
+assert_eq!(Some("Mr."), oscar.honorific_prefix());
 assert_eq!("Oscar de la Hoya, Jr.", oscar.display_full());
 
 assert!(Name::parse("foo@bar.com").is_none());
@@ -146,14 +147,8 @@ Inspiration, heuristics, and test cases were taken from:
 * [`namae` (Ruby)](https://github.com/berkmancenter/namae)
 * [`Lingua::EN::NameParse` (Perl)](http://search.cpan.org/~kimryan/Lingua-EN-NameParse-1.33/lib/Lingua/EN/NameParse.pm) (probably the original for some of the other ports as well)
 * [`Lingua::EN::Nickname` (Perl)](http://search.cpan.org/~brianl/Lingua-EN-Nickname-1.16/Nickname.pm)
-
-In terms of name formats, `human_name` covers just about all the cases these libraries
-do, and more. However, at the moment, unlike most of them, it throws away titles and
-nicknames, rather than merely separating them.
-
-I wrote this mostly as a side project to learn Rust (so apologies for any
-unidiomatic code), but thanks also to Academia.edu for giving me real-world use
-cases.
+* [`parse-full-name` (JS)] (https://github.com/dschnelldavis/parse-full-name)
+* [`PHP-Name-Parser` (PHP)] (https://github.com/joshfraser/PHP-Name-Parser)
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ assert!(!jane_doe.consistent_with(&john_doe));
 let oscar = Name::parse("MR OSCAR DE LA HOYA JR").unwrap();
 assert_eq!(Some("Oscar"), oscar.given_name());
 assert_eq!("de la Hoya", oscar.surname());
-assert_eq!(Some("Jr."), oscar.suffix());
+assert_eq!(Some("Jr."), oscar.generational_suffix());
 assert_eq!("Oscar de la Hoya, Jr.", oscar.display_full());
 
 assert!(Name::parse("foo@bar.com").is_none());
@@ -74,7 +74,7 @@ $ human_name parse "Jane Doe"
 {"first_initial":"J","given_name":"Jane","surname":"Doe"}
 
 $ human_name parse "MR OSCAR DE LA HOYA JR"
-{"first_initial":"O","given_name":"Oscar","suffix":"Jr.","surname":"de la Hoya"}
+{"first_initial":"O","given_name":"Oscar","generational_suffix":"Jr.","surname":"de la Hoya"}
 
 $ human_name eq "Jane Doe" "Jane M. Doe"
 y

--- a/src/external.rs
+++ b/src/external.rs
@@ -99,8 +99,14 @@ pub unsafe extern "C" fn human_name_middle_names(name: &Name) -> *const c_char {
 }
 
 #[no_mangle]
+#[deprecated(since = "1.1.0", note = "Use `generational_suffix` instead")]
 pub unsafe extern "C" fn human_name_suffix(name: &Name) -> *const c_char {
-    option_str_to_char_star!(name.suffix())
+    option_str_to_char_star!(name.generational_suffix())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn human_name_generational_suffix(name: &Name) -> *const c_char {
+    option_str_to_char_star!(name.generational_suffix())
 }
 
 #[no_mangle]

--- a/src/external.rs
+++ b/src/external.rs
@@ -110,6 +110,16 @@ pub unsafe extern "C" fn human_name_generational_suffix(name: &Name) -> *const c
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn human_name_honorific_prefix(name: &Name) -> *const c_char {
+    option_str_to_char_star!(name.honorific_prefix())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn human_name_honorific_suffix(name: &Name) -> *const c_char {
+    option_str_to_char_star!(name.honorific_suffix())
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn human_name_display_first_last(name: &Name) -> *const c_char {
     str_to_char_star!(name.display_first_last().into_owned())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ use std::borrow::Cow;
 use std::collections::hash_map::DefaultHasher;
 use std::convert::TryInto;
 use std::hash::{Hash, Hasher};
+use std::num::NonZeroU8;
 use std::ops::Range;
 use utils::{lowercase_if_alpha, normalize_nfkd_whitespace, transliterate};
 use word::{WordIndices, Words};
@@ -90,7 +91,7 @@ pub struct Name {
     text: SmallString<[u8; 32]>,
     word_indices_in_text: WordIndices,
     surname_index: u16, // u16 must be sufficient since it can represent MAX_NAME_LEN
-    generation_from_suffix: Option<u8>,
+    generation_from_suffix: Option<NonZeroU8>,
     initials: SmallString<[u8; 8]>,
     word_indices_in_initials: WordIndices,
     pub hash: u64,
@@ -179,7 +180,7 @@ impl Name {
     fn initialize_struct(
         words: &[NamePart],
         surname_index: usize,
-        generation_from_suffix: Option<u8>,
+        generation_from_suffix: Option<NonZeroU8>,
         name_len: usize,
     ) -> Name {
         let last_word = words.len() - 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ impl Name {
     /// assert_eq!("Velasquez y Garcia", name.surname());
     /// assert_eq!(Some("Juan"), name.given_name());
     /// assert_eq!(Some("AT"), name.middle_initials());
-    /// assert_eq!(Some("III"), name.suffix());
+    /// assert_eq!(Some("III"), name.generational_suffix());
     /// ```
     ///
     /// # Supported formats
@@ -379,9 +379,15 @@ impl Name {
     }
 
     /// Generational suffix, if present
-    pub fn suffix(&self) -> Option<&str> {
+    pub fn generational_suffix(&self) -> Option<&str> {
         self.generation_from_suffix
             .map(suffix::display_generational_suffix)
+    }
+
+    /// Generational suffix, if present
+    #[deprecated(since = "1.1.0", note = "Use `generational_suffix` instead")]
+    pub fn suffix(&self) -> Option<&str> {
+        self.generational_suffix()
     }
 
     /// First initial (with period) and surname.

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -4,13 +4,14 @@ use super::surname;
 use super::title;
 use super::utils::is_mixed_case;
 use smallvec::SmallVec;
+use std::num::NonZeroU8;
 
 #[derive(Debug)]
 struct ParseOp<'a> {
     // Output
     words: SmallVec<[NamePart<'a>; 7]>,
     surname_index: usize,
-    generation_from_suffix: Option<u8>,
+    generation_from_suffix: Option<NonZeroU8>,
 
     // Working space
     possible_false_prefix: Option<NamePart<'a>>,
@@ -20,7 +21,7 @@ struct ParseOp<'a> {
 
 pub const MAX_WORDS: usize = u8::max_value() as usize;
 
-pub fn parse(name: &str) -> Option<(SmallVec<[NamePart; 7]>, usize, Option<u8>)> {
+pub fn parse(name: &str) -> Option<(SmallVec<[NamePart; 7]>, usize, Option<NonZeroU8>)> {
     let mut op = ParseOp {
         words: SmallVec::new(),
         surname_index: 0,
@@ -375,7 +376,7 @@ mod tests {
         assert_eq!("John", parts[0].word);
         assert_eq!("Doe", parts[1].word);
         assert_eq!(1, surname_index);
-        assert_eq!(Some(3), generation);
+        assert_eq!(NonZeroU8::new(3), generation);
     }
 
     #[test]
@@ -384,7 +385,7 @@ mod tests {
         assert_eq!("John", parts[0].word);
         assert_eq!("Doe", parts[1].word);
         assert_eq!(1, surname_index);
-        assert_eq!(Some(3), generation);
+        assert_eq!(NonZeroU8::new(3), generation);
     }
 
     #[test]
@@ -393,13 +394,13 @@ mod tests {
         assert_eq!("John", parts[0].word);
         assert_eq!("Doe", parts[1].word);
         assert_eq!(1, surname_index);
-        assert_eq!(Some(2), generation);
+        assert_eq!(NonZeroU8::new(2), generation);
 
         let (parts, surname_index, generation) = parse("Griffey, Jr., Ken").unwrap();
         assert_eq!("Ken", parts[0].word);
         assert_eq!("Griffey", parts[1].word);
         assert_eq!(1, surname_index);
-        assert_eq!(Some(2), generation);
+        assert_eq!(NonZeroU8::new(2), generation);
     }
 
     #[cfg(feature = "bench")]

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -6,10 +6,18 @@ use std::borrow::Cow;
 struct PrettyNameParts<'a> {
     first_initial: char,
     surname: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
     given_name: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     middle_initials: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     middle_names: Option<Cow<'a, str>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     generational_suffix: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    honorific_prefix: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    honorific_suffix: Option<&'a str>,
 }
 
 impl Name {
@@ -21,6 +29,8 @@ impl Name {
             middle_initials: self.middle_initials(),
             middle_names: self.middle_name(),
             generational_suffix: self.generational_suffix(),
+            honorific_prefix: self.honorific_prefix(),
+            honorific_suffix: self.honorific_suffix(),
         }
     }
 }
@@ -31,9 +41,9 @@ impl Serialize for Name {
     /// ```
     /// use human_name::Name;
     ///
-    /// let name = Name::parse("JOHN ALLEN Q MACDONALD JR").unwrap();
+    /// let name = Name::parse("DR JOHN ALLEN Q MACDONALD JR").unwrap();
     /// assert_eq!(
-    ///   r#"{"first_initial":"J","surname":"MacDonald","given_name":"John","middle_initials":"AQ","middle_names":"Allen","generational_suffix":"Jr."}"#,
+    ///   r#"{"first_initial":"J","surname":"MacDonald","given_name":"John","middle_initials":"AQ","middle_names":"Allen","generational_suffix":"Jr.","honorific_prefix":"DR"}"#,
     ///   serde_json::to_string(&name).unwrap()
     /// );
     /// ```

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -9,7 +9,7 @@ struct PrettyNameParts<'a> {
     given_name: Option<&'a str>,
     middle_initials: Option<&'a str>,
     middle_names: Option<Cow<'a, str>>,
-    suffix: Option<&'a str>,
+    generational_suffix: Option<&'a str>,
 }
 
 impl Name {
@@ -20,7 +20,7 @@ impl Name {
             given_name: self.given_name(),
             middle_initials: self.middle_initials(),
             middle_names: self.middle_name(),
-            suffix: self.suffix(),
+            generational_suffix: self.generational_suffix(),
         }
     }
 }
@@ -33,7 +33,7 @@ impl Serialize for Name {
     ///
     /// let name = Name::parse("JOHN ALLEN Q MACDONALD JR").unwrap();
     /// assert_eq!(
-    ///   r#"{"first_initial":"J","surname":"MacDonald","given_name":"John","middle_initials":"AQ","middle_names":"Allen","suffix":"Jr."}"#,
+    ///   r#"{"first_initial":"J","surname":"MacDonald","given_name":"John","middle_initials":"AQ","middle_names":"Allen","generational_suffix":"Jr."}"#,
     ///   serde_json::to_string(&name).unwrap()
     /// );
     /// ```

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -43,7 +43,7 @@ impl Serialize for Name {
     ///
     /// let name = Name::parse("DR JOHN ALLEN Q MACDONALD JR").unwrap();
     /// assert_eq!(
-    ///   r#"{"first_initial":"J","surname":"MacDonald","given_name":"John","middle_initials":"AQ","middle_names":"Allen","generational_suffix":"Jr.","honorific_prefix":"DR"}"#,
+    ///   r#"{"first_initial":"J","surname":"MacDonald","given_name":"John","middle_initials":"AQ","middle_names":"Allen","generational_suffix":"Jr.","honorific_prefix":"Dr."}"#,
     ///   serde_json::to_string(&name).unwrap()
     /// );
     /// ```

--- a/src/suffix.rs
+++ b/src/suffix.rs
@@ -1,5 +1,6 @@
 use namepart::{Category, NamePart};
 use phf::phf_map;
+use std::num::NonZeroU8;
 
 static GENERATION_BY_SUFFIX: phf::Map<&'static str, u8> = phf_map! {
     // Namecased
@@ -72,7 +73,7 @@ static GENERATION_BY_SUFFIX: phf::Map<&'static str, u8> = phf_map! {
 
 static SUFFIX_BY_GENERATION: [&str; 5] = ["Sr.", "Jr.", "III", "IV", "V"];
 
-pub fn generation_from_suffix(part: &NamePart, might_be_initials: bool) -> Option<u8> {
+pub fn generation_from_suffix(part: &NamePart, might_be_initials: bool) -> Option<NonZeroU8> {
     match part.category {
         Category::Name(ref namecased) => {
             let namecased: &str = namecased;
@@ -87,10 +88,11 @@ pub fn generation_from_suffix(part: &NamePart, might_be_initials: bool) -> Optio
         }
         _ => None,
     }
+    .and_then(NonZeroU8::new)
 }
 
-pub fn display_generational_suffix(generation: u8) -> &'static str {
-    SUFFIX_BY_GENERATION[generation as usize - 1]
+pub fn display_generational_suffix(generation: NonZeroU8) -> &'static str {
+    SUFFIX_BY_GENERATION[usize::from(generation.get() - 1)]
 }
 
 #[cfg(test)]
@@ -107,25 +109,25 @@ mod tests {
     #[test]
     fn jr() {
         let part = NamePart::from_word("Jr", true, Location::Start);
-        assert_eq!(Some(2), generation_from_suffix(&part, true));
+        assert_eq!(NonZeroU8::new(2), generation_from_suffix(&part, true));
     }
 
     #[test]
     fn jr_dot() {
         let part = NamePart::from_word("Jr", true, Location::Start);
-        assert_eq!(Some(2), generation_from_suffix(&part, true));
+        assert_eq!(NonZeroU8::new(2), generation_from_suffix(&part, true));
     }
 
     #[test]
     fn iv() {
         let part = NamePart::from_word("IV", true, Location::Start);
-        assert_eq!(Some(4), generation_from_suffix(&part, true));
+        assert_eq!(NonZeroU8::new(4), generation_from_suffix(&part, true));
     }
 
     #[test]
     fn i() {
         let part = NamePart::from_word("I", true, Location::Start);
         assert_eq!(None, generation_from_suffix(&part, true));
-        assert_eq!(Some(1), generation_from_suffix(&part, false));
+        assert_eq!(NonZeroU8::new(1), generation_from_suffix(&part, false));
     }
 }

--- a/src/title.rs
+++ b/src/title.rs
@@ -1,406 +1,572 @@
 use super::namepart::{Category, NamePart};
 use super::suffix;
-use phf::phf_set;
+use super::utils;
+use phf::phf_map;
 use std::cmp;
+use Cow;
 
 static TWO_CHAR_TITLES: [&str; 4] = ["mr", "ms", "sr", "dr"];
 
-static PREFIX_TITLE_PARTS: phf::Set<&'static str> = phf_set! {
-    "Aunt",
-    "Auntie",
-    "Attaché",
-    "Dame",
-    "Marchioness",
-    "Marquess",
-    "Marquis",
-    "Marquise",
-    "King",
-    "King'S",
-    "Queen",
-    "Queen'S",
-    "Abbess",
-    "Abbot",
-    "Academic",
-    "Acolyte",
-    "Adept",
-    "Adjutant",
-    "Adm",
-    "Admiral",
-    "Advocate",
-    "Akhoond",
-    "Air",
-    "Ald",
-    "Alderman",
-    "Almoner",
-    "Ambassador",
-    "Amn",
-    "Analytics",
-    "Appellate",
-    "Apprentice",
-    "Arbitrator",
-    "Archbishop",
-    "Archdeacon",
-    "Archdruid",
-    "Archduchess",
-    "Archduke",
-    "Arhat",
-    "Assistant",
-    "Assoc",
-    "Associate",
-    "Asst",
-    "Attache",
-    "Attorney",
-    "Ayatollah",
-    "Baba",
-    "Bailiff",
-    "Banner",
-    "Bard",
-    "Baron",
-    "Barrister",
-    "Bearer",
-    "Bench",
-    "Bgen",
-    "Bishop",
-    "Blessed",
-    "Bodhisattva",
-    "Brig",
-    "Brigadier",
-    "Briggen",
-    "Brother",
-    "Buddha",
-    "Burgess",
-    "Business",
-    "Bwana",
-    "Canon",
-    "Capt",
-    "Captain",
-    "Cardinal",
-    "Chargé",
-    "Catholicos",
-    "Ccmsgt",
-    "Cdr",
-    "Ceo",
-    "Cfo",
-    "Chair",
-    "Chairs",
-    "Chancellor",
-    "Chaplain",
-    "Chief",
-    "Chieftain",
-    "Civil",
-    "Clerk",
-    "Cmd",
-    "Cmdr",
-    "Cmsaf",
-    "Cmsgt",
-    "Co-Chair",
-    "Co-Chairs",
-    "Coach",
-    "Col",
-    "Colonel",
-    "Commander",
-    "Commander-In-Chief",
-    "Commodore",
-    "Comptroller",
-    "Controller",
-    "Corporal",
-    "Corporate",
-    "Councillor",
-    "Count",
-    "Countess",
-    "Courtier",
-    "Cpl",
-    "Cpo",
-    "Cpt",
-    "Credit",
-    "Criminal",
-    "Csm",
-    "Curator",
-    "Customs",
-    "Cwo",
-    "D'Affaires",
-    "Deacon",
-    "Delegate",
-    "Deputy",
-    "Designated",
-    "Det",
-    "Dir",
-    "Director",
-    "Discovery",
-    "District",
-    "Division",
-    "Docent",
-    "Docket",
-    "Doctor",
-    "Doyen",
-    "Dpty",
-    "Druid",
-    "Duke",
-    "Dutchess",
-    "Edmi",
-    "Edohen",
-    "Effendi",
-    "Ekegbian",
-    "Elder",
-    "Elerunwon",
-    "Emperor",
-    "Empress",
-    "Ens",
-    "Envoy",
-    "Exec",
-    "Executive",
-    "Fadm",
-    "Family",
-    "Father",
-    "Federal",
-    "Field",
-    "Financial",
-    "First",
-    "Flag",
-    "Flying",
-    "Flight",
-    "Flt",
-    "Foreign",
-    "Forester",
-    "Frau",
-    "Friar",
-    "Gen",
-    "General",
-    "Generalissimo",
-    "Gentiluomo",
-    "Giani",
-    "Goodman",
-    "Goodwife",
-    "Governor",
-    "Grand",
-    "Group",
-    "Guru",
-    "Gyani",
-    "Gysgt",
-    "Hajji",
-    "Headman",
-    "Her",
-    "Herr",
-    "Hereditary",
-    "High",
-    "His",
-    "Hon",
-    "Honorable",
-    "Honourable",
-    "Imam",
-    "Information",
-    "Insp",
-    "Intelligence",
-    "Intendant",
-    "Journeyman",
-    "Judge",
-    "Judicial",
-    "Justice",
-    "Junior",
-    "Kingdom",
-    "Knowledge",
-    "Lady",
-    "Lama",
-    "Lamido",
-    "Law",
-    "Lcdr",
-    "Lcpl",
-    "Leader",
-    "Lieutenant",
-    "Lord",
-    "Leut",
-    "Lieut",
-    "Ltc",
-    "Ltcol",
-    "Ltg",
-    "Ltgen",
-    "Ltjg",
-    "Madam",
-    "Madame",
-    "Mag",
-    "Mag-Judge",
-    "Mag/Judge",
-    "Magistrate",
-    "Magistrate-Judge",
-    "Maharajah",
-    "Maharani",
-    "Mahdi",
-    "Maid",
-    "Maj",
-    "Majesty",
-    "Majgen",
-    "Major",
-    "Manager",
-    "Marcher",
-    "Marketing",
-    "Marshal",
-    "Master",
-    "Matriarch",
-    "Matron",
-    "Mayor",
-    "Mcpo",
-    "Mcpoc",
-    "Mcpon",
-    "Member",
-    "Metropolitan",
-    "Mgr",
-    "Mgysgt",
-    "Minister",
-    "Miss",
-    "Misses",
-    "Mister",
-    "Mme",
-    "Monsignor",
-    "Most",
-    "Mother",
-    "Mpco-Cg",
-    "Mrs",
-    "Msg",
-    "Msgr",
-    "Msgt",
-    "Mufti",
-    "Mullah",
-    "Municipal",
-    "Murshid",
-    "Nanny",
-    "National",
-    "Nurse",
-    "Officer",
-    "Operating",
-    "Pastor",
-    "Patriarch",
-    "Petty",
-    "Pfc",
-    "Pharaoh",
-    "Pilot",
-    "Pir",
-    "Police",
-    "Political",
-    "Pope",
-    "Prefect",
-    "Prelate",
-    "Premier",
-    "Pres",
-    "Presbyter",
-    "President",
-    "Presiding",
-    "Priest",
-    "Priestess",
-    "Primate",
-    "Prime",
-    "Prin",
-    "Prince",
-    "Princess",
-    "Principal",
-    "Prior",
-    "Private",
-    "Pro",
-    "Prof",
-    "Professor",
-    "Provost",
-    "Pslc",
-    "Pte",
-    "Pursuivant",
-    "Pvt",
-    "Rabbi",
-    "Radm",
-    "Rangatira",
-    "Ranger",
-    "Rdml",
-    "Rear",
-    "Rebbe",
-    "Registrar",
-    "Rep",
-    "Representative",
-    "Resident",
-    "Rev",
-    "Revenue",
-    "Reverend",
-    "Reverand",
-    "Revd",
-    "Right",
-    "Risk",
-    "Royal",
-    "Saint",
-    "Sargent",
-    "Sargeant",
-    "Saoshyant",
-    "Scpo",
-    "Secretary",
-    "Security",
-    "Seigneur",
-    "Senator",
-    "Senior",
-    "Senior-Judge",
-    "Sergeant",
-    "Servant",
-    "Sfc",
-    "Sgm",
-    "Sgt",
-    "Sgtmaj",
-    "Sgtmajmc",
-    "Shehu",
-    "Sheikh",
-    "Sheriff",
-    "Siddha",
-    "Sir",
-    "Sister",
-    "Sma",
-    "Smsgt",
-    "Solicitor",
-    "Spc",
-    "Speaker",
-    "Special",
-    "Sra",
-    "Ssg",
-    "Ssgt",
-    "Staff",
-    "State",
-    "States",
-    "Strategy",
-    "Subaltern",
-    "Subedar",
-    "Sultan",
-    "Sultana",
-    "Superior",
-    "Supreme",
-    "Surgeon",
-    "Swordbearer",
-    "Sysselmann",
-    "Tax",
-    "Technical",
-    "Timi",
-    "Tirthankar",
-    "Treasurer",
-    "Tsar",
-    "Tsarina",
-    "Tsgt",
-    "Uncle",
-    "United",
-    "Vadm",
-    "Vardapet",
-    "Venerable",
-    "Verderer",
-    "Very",
-    "Vicar",
-    "Vice",
-    "Viscount",
-    "Vizier",
-    "Warden",
-    "Warrant",
-    "Wing",
-    "Woodman",
-    "And",
-    "The",
-    "Und",
+static PREFIX_HONORIFICS: phf::Map<&'static str, &'static str> = phf_map! {
+    "Aunt" => "Aunt",
+    "Auntie" => "Auntie",
+    "Attaché" => "Attaché",
+    "Dame" => "Dame",
+    "Marchioness" => "Marchioness",
+    "Marquess" => "Marquess",
+    "Marquis" => "Marquis",
+    "Marquise" => "Marquise",
+    "King" => "King",
+    "King'S" => "King's",
+    "Queen" => "Queen",
+    "Queen'S" => "Queen's",
+    "Abbess" => "Abbess",
+    "Abbot" => "Abbot",
+    "Acad" => "Acad.",
+    "Academic" => "Acad.",
+    "Academian" => "Acad.",
+    "Acolyte" => "Acolyte",
+    "Adept" => "Adept",
+    "Adjutant" => "Adjutant",
+    "Adm" => "Adm.",
+    "Admiral" => "Adm.",
+    "Administrative" => "Adm.",
+    "Administrator" => "Adm.",
+    "Administrater" => "Adm.",
+    "Admin" => "Adm.",
+    "Advocate" => "Advocate",
+    "Akhoond" => "Akhoond",
+    "Air" => "Air",
+    "Amn" => "Amn.",
+    "Airman" => "Amn.",
+    "Ald" => "Ald.",
+    "Alderman" => "Ald.",
+    "Almoner" => "Almoner",
+    "Ambassador" => "Amb.",
+    "Amb" => "Amb.",
+    "Analytics" => "Analytics",
+    "Appellate" => "Appellate",
+    "Apprentice" => "Apprentice",
+    "Arbitrator" => "Arbitrator",
+    "Archbishop" => "Archbishop",
+    "Archdeacon" => "Archdeacon",
+    "Archdruid" => "Archdruid",
+    "Archduchess" => "Archduchess",
+    "Archduke" => "Archduke",
+    "Arhat" => "Arhat",
+    "As" => "Asst.",
+    "Assistant" => "Asst.",
+    "Assoc" => "Assoc.",
+    "Associate" => "Assoc.",
+    "Asst" => "Asst.",
+    "Attache" => "Attache",
+    "Attorney" => "Attorney",
+    "Ayatollah" => "Ayatollah",
+    "Baba" => "Baba",
+    "Bachelor" => "Bachelor",
+    "Baccalaureus" => "Baccalaureus",
+    "Bailiff" => "Bailiff",
+    "Banner" => "Banner",
+    "Bard" => "Bard",
+    "Baron" => "Baron",
+    "Barrister" => "Barrister",
+    "Bearer" => "Bearer",
+    "Bench" => "Bench",
+    "Bgen" => "Brig. Gen.",
+    "Bishop" => "Bishop",
+    "Blessed" => "Blessed",
+    "Bodhisattva" => "Bodhisattva",
+    "Brig" => "Brig.",
+    "Brigadier" => "Brig.",
+    "Briggen" => "Briggen",
+    "Brother" => "Br.",
+    "Br" => "Br.",
+    "Buddha" => "Buddha",
+    "Burgess" => "Burgess",
+    "Business" => "Business",
+    "Bwana" => "Bwana",
+    "Canon" => "Canon",
+    "Capt" => "Capt.",
+    "Captain" => "Capt.",
+    "Cardinal" => "Cardinal",
+    "Chargé" => "Chargé",
+    "Catholicos" => "Catholicos",
+    "Ccmsgt" => "CCM",
+    "Cdr" => "Cdr.",
+    "Ceo" => "CEO",
+    "Cfo" => "CFO",
+    "Chair" => "Chair",
+    "Chairs" => "Chairs",
+    "Chancellor" => "Chancellor",
+    "Chaplain" => "Chaplain",
+    "Chief" => "Chief",
+    "Chieftain" => "Chieftain",
+    "Civil" => "Civil",
+    "Clerk" => "Clerk",
+    "Cmd" => "Cmd.",
+    "Cmdr" => "Cmdr.",
+    "Cmsaf" => "CMSAF",
+    "Cmsgt" => "CMSgt",
+    "Co-Chair" => "Co-Chair",
+    "Co-Chairs" => "Co-Chairs",
+    "Coach" => "Coach",
+    "Col" => "Col.",
+    "Colonel" => "Col.,",
+    "Commander" => "Cmdr.",
+    "Commander-In-Chief" => "Commander-In-Chief",
+    "Commodore" => "Commodore",
+    "Comptroller" => "Comptroller",
+    "Controller" => "Controller",
+    "Corporal" => "Cpl.",
+    "Corporate" => "Corporate",
+    "Councillor" => "Councillor",
+    "Count" => "Count",
+    "Countess" => "Countess",
+    "Courtier" => "Courtier",
+    "Cpl" => "Cpl.",
+    "Cpo" => "CPO",
+    "Cpt" => "Capt.",
+    "Credit" => "Credit",
+    "Criminal" => "Criminal",
+    "Csm" => "CSM",
+    "Curator" => "Curator",
+    "Customs" => "Customs",
+    "Cwo" => "CWO",
+    "D'Affaires" => "D'Affaires",
+    "Deacon" => "Deacon",
+    "Delegate" => "Delegate",
+    "Deputy" => "Deputy",
+    "Designated" => "Designated",
+    "Det" => "Det.",
+    "Detective" => "Det.",
+    "Dir" => "Dir.",
+    "Director" => "Dir.",
+    "Discovery" => "Discovery",
+    "District" => "District",
+    "Division" => "Division",
+    "Docent" => "Docent",
+    "Docket" => "Docket",
+    "Doctor" => "Dr.",
+    "Doc" => "Dr.",
+    "Doyen" => "Doyen",
+    "Dpty" => "Deputy",
+    "Druid" => "Druid",
+    "Duke" => "Duke",
+    "Duchess" => "Duchess",
+    "Edmi" => "Edmi",
+    "Edohen" => "Edohen",
+    "Effendi" => "Effendi",
+    "Ekegbian" => "Ekegbian",
+    "Elder" => "Elder",
+    "Elerunwon" => "Elerunwon",
+    "Emperor" => "Emperor",
+    "Empress" => "Empress",
+    "Engineer" => "Eng.",
+    "Ens" => "Ens.",
+    "Ensign" => "Ensign",
+    "Envoy" => "Envoy",
+    "Exec" => "Exec.",
+    "Executive" => "Exec.",
+    "Fadm" => "FADM",
+    "Family" => "Family",
+    "Father" => "Fr.",
+    "Fr" => "Fr.",
+    "Federal" => "Federal",
+    "Field" => "Field",
+    "Financial" => "Financial",
+    "First" => "First",
+    "Flag" => "Flag",
+    "Flying" => "Flying",
+    "Flight" => "Flt.",
+    "Flt" => "Flt.",
+    "Foreign" => "Foreign",
+    "Forester" => "Forester",
+    "Frau" => "Frau",
+    "Friar" => "Friar",
+    "Gen" => "Gen.",
+    "General" => "Gen.",
+    "Generalissimo" => "Gen.",
+    "Gentiluomo" => "Gentiluomo",
+    "Giani" => "Giani",
+    "Goodman" => "Goodman",
+    "Goodwife" => "Goodwife",
+    "Gov" => "Gov.",
+    "Governer" => "Gov.",
+    "Governor" => "Gov.",
+    "Grand" => "Grand",
+    "Group" => "Group",
+    "Guru" => "Guru",
+    "Gyani" => "Gyani",
+    "Gysgt" => "GySgt",
+    "Hajji" => "Hajji",
+    "Headman" => "Headman",
+    "Her" => "Her",
+    "Herr" => "Herr",
+    "Hereditary" => "Hereditary",
+    "High" => "High",
+    "His" => "His",
+    "Hon" => "Hon.",
+    "Honorable" => "Hon.",
+    "Honourable" => "Hon.",
+    "Imam" => "Imam",
+    "Information" => "Information",
+    "Insp" => "Insp.",
+    "Inspector" => "Insp.",
+    "Intelligence" => "Intelligence",
+    "Intendant" => "Intendant",
+    "Journeyman" => "Journeyman",
+    "Judge" => "Judge",
+    "Judicial" => "Judicial",
+    "Justice" => "Justice",
+    "Junior" => "Jr.",
+    "Jr" => "Jr.",
+    "Kingdom" => "Kingdom",
+    "Knowledge" => "Knowledge",
+    "Lady" => "Lady",
+    "Lama" => "Lama",
+    "Lamido" => "Lamido",
+    "Law" => "Law",
+    "Lcdr" => "LCDR",
+    "Lcpl" => "LCpl",
+    "Leader" => "Leader",
+    "Lieutenant" => "Lt.",
+    "Lord" => "Lord",
+    "Leut" => "Lt.",
+    "Lieut" => "Lt.",
+    "Ltc" => "Lt. Col.",
+    "Ltcol" => "Lt. Col.",
+    "Ltg" => "Lt. Gen.",
+    "Ltgen" => "Lt. Gen.",
+    "Ltjg" => "LTJG",
+    "Madam" => "Madam",
+    "Madame" => "Mme.",
+    "Mag" => "Mag.",
+    "Mag-Judge" => "Magistrate Judge",
+    "Mag/Judge" => "Magistrate udge",
+    "Magistrate" => "Magistrate",
+    "Magistrate-Judge" => "Magistrate Judge",
+    "Maharajah" => "Maharajah",
+    "Maharani" => "Maharani",
+    "Mahdi" => "Mahdi",
+    "Maid" => "Maid",
+    "Maj" => "Maj.",
+    "Majesty" => "Majesty",
+    "Majgen" => "Maj. Gen.",
+    "Major" => "Maj.",
+    "Manager" => "Mgr.",
+    "Marcher" => "Marcher",
+    "Marketing" => "Marketing",
+    "Marshal" => "Marshal",
+    "Master" => "Mr.",
+    "Matriarch" => "Matriarch",
+    "Matron" => "Matron",
+    "Mayor" => "Mayor",
+    "Mcpo" => "MCPO",
+    "Mcpoc" => "MCPOC",
+    "Mcpon" => "MCPON",
+    "Member" => "Member",
+    "Metropolitan" => "Metropolitan",
+    "Mgr" => "Mgr.",
+    "Mgysgt" => "MGySgt",
+    "Minister" => "Minister",
+    "Miss" => "Ms.",
+    "Misses" => "Misses",
+    "Mister" => "Mr.",
+    "Mme" => "Mme.",
+    "Monsignor" => "Msgr.",
+    "Most" => "Most",
+    "Mother" => "Mother",
+    "Mpco-Cg" => "MCPOCG",
+    "Mrs" => "Mrs.",
+    "Missus" => "Mrs.",
+    "Msg" => "MSG",
+    "Msgr" => "Msgr.",
+    "Msgt" => "MSgt",
+    "Mufti" => "Mufti",
+    "Mullah" => "Mullah",
+    "Municipal" => "Municipal",
+    "Murshid" => "Murshid",
+    "Mx" => "Mx.",
+    "Mz" => "Mz.",
+    "Nanny" => "Nanny",
+    "National" => "National",
+    "Nurse" => "Nurse",
+    "Officer" => "Ofc.",
+    "Ofc" => "Ofc.",
+    "Operating" => "Operating",
+    "Pastor" => "Pastor",
+    "Patriarch" => "Patriarch",
+    "Petty" => "Petty",
+    "Pfc" => "PFC",
+    "Pharaoh" => "Pharaoh",
+    "Pilot" => "Pilot",
+    "Pir" => "Pir",
+    "Police" => "Police",
+    "Political" => "Political",
+    "Pope" => "Pope",
+    "Prefect" => "Prefect",
+    "Prelate" => "Prelate",
+    "Premier" => "Premier",
+    "Pres" => "Pres.",
+    "Presbyter" => "Presbyter",
+    "President" => "Pres.",
+    "Presiding" => "Presiding",
+    "Priest" => "Priest",
+    "Priestess" => "Priestess",
+    "Primate" => "Primate",
+    "Prime" => "Prime",
+    "Prin" => "Prin.",
+    "Prince" => "Prince",
+    "Princess" => "Princess",
+    "Principal" => "Prin.",
+    "Prior" => "Prior",
+    "Private" => "Pvt.",
+    "Pro" => "Pro",
+    "Prof" => "Prof.",
+    "Professor" => "Prof.",
+    "Provost" => "Provost",
+    "Pte" => "Pte.",
+    "Pursuivant" => "Pursuivant",
+    "Pvt" => "Pvt.",
+    "Rabbi" => "Rabbi",
+    "Radm" => "RADM",
+    "Rangatira" => "Rangatira",
+    "Ranger" => "Ranger",
+    "Rdml" => "RDML",
+    "Rear" => "Rear",
+    "Rebbe" => "Rebbe",
+    "Registrar" => "Registrar",
+    "Rep" => "Rep.",
+    "Representative" => "Rep.",
+    "Resident" => "Resident",
+    "Rev" => "Rev.",
+    "Revenue" => "Revenue",
+    "Reverend" => "Rev.",
+    "Reverand" => "Rev.",
+    "Revd" => "Rev.",
+    "Rev'D" => "Rev.",
+    "Right" => "Right",
+    "Risk" => "Risk",
+    "Royal" => "Royal",
+    "Saint" => "Saint",
+    "Sargent" => "Sgt.",
+    "Sargeant" => "Sgt.",
+    "Saoshyant" => "Saoshyant",
+    "Scpo" => "SCPO",
+    "Secretary" => "Sec.",
+    "Sec" => "Sec.",
+    "Security" => "Security",
+    "Seigneur" => "Seigneur",
+    "Senator" => "Sen.",
+    "Sen" => "Sen.",
+    "Senior" => "Senior",
+    "Senior-Judge" => "Senior-Judge",
+    "Sergeant" => "Sgt.",
+    "Servant" => "Servant",
+    "Sfc" => "SFC",
+    "Sgm" => "SGM",
+    "Sgt" => "Sgt.",
+    "Sgtmaj" => "SGM",
+    "Sgtmajmc" => "SMMC",
+    "Shehu" => "Shehu",
+    "Sheikh" => "Sheikh",
+    "Sheriff" => "Sheriff",
+    "Siddha" => "Siddha",
+    "Sir" => "Sir",
+    "Sister" => "Sr.",
+    "Sr" => "Sr.",
+    "Sma" => "SMA",
+    "Smsgt" => "SMSgt",
+    "Solicitor" => "Solicitor",
+    "Spc" => "SPC",
+    "Speaker" => "Speaker",
+    "Special" => "Special",
+    "Specialist" => "Specialist",
+    "Sra" => "SrA",
+    "Ssg" => "SSG",
+    "Ssgt" => "SSgt",
+    "Staff" => "Staff",
+    "State" => "State",
+    "States" => "States",
+    "Strategy" => "Strategy",
+    "Subaltern" => "Subaltern",
+    "Subedar" => "Subedar",
+    "Sultan" => "Sultan",
+    "Sultana" => "Sultana",
+    "Superior" => "Superior",
+    "Superintendent" => "Supt.",
+    "Supt" => "Supt.",
+    "Supreme" => "Supreme",
+    "Surgeon" => "Surgeon",
+    "Swordbearer" => "Swordbearer",
+    "Sysselmann" => "Sysselmann",
+    "Tax" => "Tax",
+    "Technical" => "Technical",
+    "Timi" => "Timi",
+    "Tirthankar" => "Tirthankar",
+    "Treasurer" => "Treas.",
+    "Treas" => "Treas.",
+    "Tsar" => "Tsar",
+    "Tsarina" => "Tsarina",
+    "Tsgt" => "TSgt",
+    "Uncle" => "Uncle",
+    "United" => "United",
+    "Vadm" => "VAdm",
+    "Vardapet" => "Vardapet",
+    "Venerable" => "Venerable",
+    "Verderer" => "Verderer",
+    "Very" => "Very",
+    "Vicar" => "Vicar",
+    "Vice" => "Vice",
+    "Viscount" => "Viscount",
+    "Vizier" => "Vizier",
+    "Warden" => "Warden",
+    "Warrant" => "Warrant",
+    "Wing" => "Wing",
+    "Woodman" => "Woodman",
+    "Icdr" => "ICDr.",
+    "Judr" => "JUDr.",
+    "Mddr" => "MDDr.",
+    "Bca" => "BcA.",
+    "Mga" => "MgA.",
+    "Md" => "M.D.",
+    "Dvm" => "DVM",
+    "Paeddr" => "PaedDr.",
+    "Pharmdr" => "PharmDr.",
+    "Phdr" => "PhDr.",
+    "Phmr" => "PhMr.",
+    "Rcdr" => "RCDr.",
+    "Rndr" => "RNDr.",
+    "Dsc" => "DSc.",
+    "Rsdr" => "RSDr.",
+    "Rtdr" => "RTDr.",
+    "Thdr" => "ThDr.",
+    "Thd" => "Th.D.",
+    "Phd" => "Ph.D.",
+    "Thlic" => "ThLic.",
+    "Thmgr" => "ThMgr.",
+    "Artd" => "ArtD.",
+    "Dis" => "DiS.",
+
+    "And" => "and",
+    "The" => "The",
+    "Und" => "und",
 };
 
-static POSTFIX_TITLES: phf::Set<&'static str> = phf_set! {
-    "Esq",
-    "Esquire",
-    "Attorney-at-law",
-    "Et",
-    "Al",
+static POSTFIX_HONORIFICS: phf::Map<&'static str, &'static str> = phf_map! {
+    "Esq" => "Esq.",
+    "Esquire" => "Esq.",
+    "Attorney-at-law" => "Attorney-at-law",
+    "Msc" => "M.Sc",
+    "Bcompt" => "BCompt",
+    "Phd" => "Ph.D.",
+    "Rph" => "RPh",
+    "Chb" => "ChB",
+    "Freng" => "FREng",
+    "Meng" => "M.Eng",
+    "Bgdipbus" => "BGDipBus",
+    "Dip" => "Dip",
+    "Diplphys" => "Dipl.Phys",
+    "Mhsc" => "M.H.Sc.",
+    "Bcomm" => "B.Comm",
+    "Beng" => "B.Eng",
+    "Bacc" => "B.Acc",
+    "Mtech" => "M.Tech",
+    "Bec" => "B.Ec",
+    "Capom" => "CAP-OM",
+    "Peng" => "P.Eng",
+    "Bch" => "BCh",
+    "Mbbchir" => "MBBChir",
+    "Mbchba" => "MBChBa",
+    "Mphil" => "MPhil",
+    "Lld" => "LL.D",
+    "Dlit" => "D.Lit",
+    "Dclinpsy" => "DClinPsy",
+    "Dsc" => "DSc",
+    "Mres" => "M.Res",
+    "Psyd" => "Psy.D",
+    "Pharmd" => "Pharm.D",
+    "Bacom" => "BACom",
+    "Badmin" => "BAdmin",
+    "Baecon" => "BAEcon",
+    "Bagr" => "BAgr",
+    "Balaw" => "BALaw",
+    "Bappsc" => "BAppSc",
+    "Barch" => "BArch",
+    "Barchsc" => "BArchSc",
+    "Barelst" => "BARelSt",
+    "Basc" => "BASc",
+    "Basoc" => "BASoc",
+    "Batheol" => "BATheol",
+    "Bbus" => "BBus",
+    "Bchem" => "BChem",
+    "Bclinsci" => "BClinSci",
+    "Bcombst" => "BCombSt",
+    "Bcommedcommdev" => "BCommEdCommDev",
+    "Bcomp" => "BComp",
+    "Bcomsc" => "BComSc",
+    "Bcoun" => "BCoun",
+    "Bdes" => "BDes",
+    "Becon" => "BEcon",
+    "Beconfin" => "BEcon&Fin",
+    "Beconsci" => "BEconSci",
+    "Bed" => "BEd",
+    "Bfin" => "BFin",
+    "Bhealthsc" => "BHealthSc",
+    "Bhsc" => "BHSc",
+    "Bhy" => "BHy",
+    "Bjur" => "BJur",
+    "Blegsc" => "BLegSc",
+    "Blib" => "BLib",
+    "Bling" => "BLing",
+    "Blitt" => "BLitt",
+    "Blittcelt" => "BLittCelt",
+    "Bmedsc" => "BMedSc",
+    "Bmet" => "BMet",
+    "Bmid" => "BMid",
+    "Bmin" => "BMin",
+    "Bmsc" => "BMSc",
+    "Bmus" => "BMus",
+    "Bmused" => "BMusEd",
+    "Bmusperf" => "BMusPerf",
+    "Bnurs" => "BNurs",
+    "Boptom" => "BOptom",
+    "Bpharm" => "BPharm",
+    "Bphil" => "BPhil",
+    "Tchg" => "Tchg",
+    "Med" => "MEd",
+    "Bachelor" => "Bachelor",
+    "Ceng" => "C.Eng",
+    "Bphys" => "BPhys",
+    "Bphysio" => "BPhysio",
+    "Bpl" => "BPl",
+    "Bradiog" => "BRadiog",
+    "Bsc" => "B.Sc",
+    "Bscagr" => "BScAgr",
+    "Bscec" => "BScEc",
+    "Bscecon" => "BScEcon",
+    "Bscfor" => "BScFor",
+    "Bsocsc" => "BSocSc",
+    "Bstsu" => "BStSu",
+    "Btchg" => "BTchg",
+    "Btech" => "BTech",
+    "Bteched" => "BTechEd",
+    "Bth" => "BTh",
+    "Btheol" => "BTheol",
+    "Edb" => "EdB",
+    "Littb" => "LittB",
+    "Musb" => "MusB",
+    "Scbtech" => "ScBTech",
+    "Cfa" => "CFA",
+    "Llb" => "LL.B",
+    "Llm" => "LL.M",
+    "Solicitor" => "Solicitor",
+    "Cenv" => "CEnv",
+    "Bcom" => "B.Com",
+    "Mec" => "MEc",
+    "Hdip" => "HDip",
+    "Et" => "et",
+    "Al" => "al.",
 };
 
 #[allow(clippy::if_same_then_else)]
@@ -412,7 +578,7 @@ fn might_be_title_part(word: &NamePart) -> bool {
         match &word.category {
             Category::Name(ref namecased) => {
                 let namecased: &str = namecased;
-                PREFIX_TITLE_PARTS.contains(namecased) || namecased.chars().any(char::is_numeric)
+                PREFIX_HONORIFICS.contains_key(namecased) || namecased.chars().any(char::is_numeric)
             }
             _ => true,
         }
@@ -455,7 +621,7 @@ fn is_postfix_title(word: &NamePart, might_be_initials: bool) -> bool {
     match word.category {
         Category::Name(ref namecased) => {
             let namecased: &str = namecased;
-            POSTFIX_TITLES.contains(namecased) || namecased.chars().any(char::is_numeric)
+            POSTFIX_HONORIFICS.contains_key(namecased) || namecased.chars().any(char::is_numeric)
         }
         Category::Initials => !might_be_initials && word.counts.alpha > 1,
         _ => true,
@@ -502,10 +668,356 @@ pub fn find_postfix_index(words: &[NamePart], expect_initials: bool) -> usize {
     )
 }
 
+pub fn canonicalize_suffix<'a>(title: &'a NamePart<'a>) -> Cow<'a, str> {
+    match &title.category {
+        Category::Name(namecased) => {
+            if let Some(canonical) = POSTFIX_HONORIFICS.get(namecased) {
+                Cow::Borrowed(canonical)
+            } else {
+                Cow::Borrowed(namecased)
+            }
+        }
+        Category::Initials => {
+            // If there's existing punctuation, assume formatting is intentional.
+            if title.counts.chars != title.counts.alpha {
+                return Cow::Borrowed(title.word);
+            }
+
+            // Otherwise, ignore case to check for a known canonical form (restricting
+            // to ASCII just for simplicity since our list of honorifics is 100% ASCII).
+            if title.counts.chars == title.counts.ascii_alpha {
+                let capitalized = utils::capitalize_word(title.word, true);
+                if let Some(canonical) = POSTFIX_HONORIFICS.get(&capitalized) {
+                    return Cow::Borrowed(canonical);
+                }
+            }
+
+            // Assume unrecognized honorifics are acronyms (given that we previously
+            // categorized as initials). For length two or less, format with periods
+            // (e.g. "M.D."), but skip periods for longer acronyms (e.g. "LCSW").
+            if title.word.len() <= 2 {
+                let mut result = String::with_capacity((title.counts.alpha * 2).into());
+                title.with_initials(|c| {
+                    for u in c.to_uppercase() {
+                        result.push(u);
+                    }
+                    result.push('.');
+                });
+                Cow::Owned(result)
+            } else {
+                let mut result = String::with_capacity((title.counts.alpha).into());
+                title.with_initials(|c| {
+                    for u in c.to_uppercase() {
+                        result.push(u);
+                    }
+                });
+                Cow::Owned(result)
+            }
+        }
+        Category::Abbreviation | Category::Other => Cow::Borrowed(title.word),
+    }
+}
+
+pub fn canonicalize_prefix<'a>(title: &'a NamePart<'a>) -> Cow<'a, str> {
+    match &title.category {
+        Category::Name(namecased) => {
+            if let Some(canonical) = PREFIX_HONORIFICS.get(namecased) {
+                Cow::Borrowed(canonical)
+            } else {
+                Cow::Borrowed(namecased)
+            }
+        }
+        Category::Initials => {
+            // If there's existing punctuation, assume formatting is intentional.
+            if title.counts.chars != title.counts.alpha {
+                return Cow::Borrowed(title.word);
+            }
+
+            // Otherwise, ignore case to check for a known canonical form (restricting
+            // to ASCII just for simplicity since our list of honorifics is 100% ASCII).
+            if title.counts.chars == title.counts.ascii_alpha {
+                let capitalized = utils::capitalize_word(title.word, true);
+                if let Some(canonical) = PREFIX_HONORIFICS.get(&capitalized) {
+                    return Cow::Borrowed(canonical);
+                }
+            }
+
+            // For unrecognized honorifics, canonicalize as an abbreviation (e.g. "Dr.").
+            let mut result = String::with_capacity((title.counts.alpha + 1).into());
+            title.with_initials(|c| {
+                if result.is_empty() {
+                    result.push(c);
+                } else {
+                    for l in c.to_lowercase() {
+                        result.push(l);
+                    }
+                }
+            });
+            result.push('.');
+            Cow::Owned(result)
+        }
+        Category::Abbreviation | Category::Other => Cow::Borrowed(title.word),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::namepart::{Location, NamePart};
     use super::*;
+
+    #[test]
+    fn canonicalize_doctor_prefix() {
+        assert_eq!(
+            "Dr.",
+            canonicalize_prefix(&NamePart::from_word("DR", true, Location::Start))
+        );
+        assert_eq!(
+            "Dr.",
+            canonicalize_prefix(&NamePart::from_word("Dr", true, Location::Start))
+        );
+        assert_eq!(
+            "Dr.",
+            canonicalize_prefix(&NamePart::from_word("dr", true, Location::Start))
+        );
+        assert_eq!(
+            "Dr.",
+            canonicalize_prefix(&NamePart::from_word("Doctor", true, Location::Start))
+        );
+        assert_eq!(
+            "Dr.",
+            canonicalize_prefix(&NamePart::from_word("Dr.", true, Location::Start))
+        );
+    }
+
+    #[test]
+    fn canonicalize_mister_prefix() {
+        assert_eq!(
+            "Mr.",
+            canonicalize_prefix(&NamePart::from_word("MR", true, Location::Start))
+        );
+        assert_eq!(
+            "Mr.",
+            canonicalize_prefix(&NamePart::from_word("Mr", true, Location::Start))
+        );
+        assert_eq!(
+            "Mr.",
+            canonicalize_prefix(&NamePart::from_word("mr", true, Location::Start))
+        );
+        assert_eq!(
+            "Mr.",
+            canonicalize_prefix(&NamePart::from_word("Mister", true, Location::Start))
+        );
+        assert_eq!(
+            "Mr.",
+            canonicalize_prefix(&NamePart::from_word("Master", true, Location::Start))
+        );
+        assert_eq!(
+            "Mr.",
+            canonicalize_prefix(&NamePart::from_word("Mr.", true, Location::Start))
+        );
+    }
+
+    #[test]
+    fn canonicalize_mrs_prefix() {
+        assert_eq!(
+            "Mrs.",
+            canonicalize_prefix(&NamePart::from_word("MRS", true, Location::Start))
+        );
+        assert_eq!(
+            "Mrs.",
+            canonicalize_prefix(&NamePart::from_word("Mrs", true, Location::Start))
+        );
+        assert_eq!(
+            "Mrs.",
+            canonicalize_prefix(&NamePart::from_word("mrs", true, Location::Start))
+        );
+        assert_eq!(
+            "Mrs.",
+            canonicalize_prefix(&NamePart::from_word("Missus", true, Location::Start))
+        );
+        assert_eq!(
+            "Mrs.",
+            canonicalize_prefix(&NamePart::from_word("Mrs.", true, Location::Start))
+        );
+    }
+
+    #[test]
+    fn canonicalize_prof_prefix() {
+        assert_eq!(
+            "Prof.",
+            canonicalize_prefix(&NamePart::from_word("PROF", true, Location::Start))
+        );
+        assert_eq!(
+            "Prof.",
+            canonicalize_prefix(&NamePart::from_word("Prof", true, Location::Start))
+        );
+        assert_eq!(
+            "Prof.",
+            canonicalize_prefix(&NamePart::from_word("prof", true, Location::Start))
+        );
+        assert_eq!(
+            "Prof.",
+            canonicalize_prefix(&NamePart::from_word("Professor", true, Location::Start))
+        );
+        assert_eq!(
+            "Prof.",
+            canonicalize_prefix(&NamePart::from_word("Prof.", true, Location::Start))
+        );
+    }
+
+    #[test]
+    fn canonicalize_sir_prefix() {
+        assert_eq!(
+            "Sir",
+            canonicalize_prefix(&NamePart::from_word("Sir", true, Location::Start))
+        );
+        assert_eq!(
+            "Sir",
+            canonicalize_prefix(&NamePart::from_word("Sir", true, Location::Start))
+        );
+        assert_eq!(
+            "Sir",
+            canonicalize_prefix(&NamePart::from_word("Sir", true, Location::Start))
+        );
+    }
+
+    #[test]
+    fn canonicalize_unrecognized_prefix() {
+        assert_eq!(
+            "Abc.",
+            canonicalize_prefix(&NamePart::from_word("ABC", true, Location::Start))
+        );
+        assert_eq!(
+            "Abc",
+            canonicalize_prefix(&NamePart::from_word("Abc", true, Location::Start))
+        );
+        assert_eq!(
+            "Abc",
+            canonicalize_prefix(&NamePart::from_word("abc", true, Location::Start))
+        );
+        assert_eq!(
+            "Abc.",
+            canonicalize_prefix(&NamePart::from_word("Abc.", true, Location::Start))
+        );
+
+        assert_eq!(
+            "Xx.",
+            canonicalize_prefix(&NamePart::from_word("XX", true, Location::Start))
+        );
+        assert_eq!(
+            "Xx.",
+            canonicalize_prefix(&NamePart::from_word("Xx", true, Location::Start))
+        );
+        assert_eq!(
+            "Xx.",
+            canonicalize_prefix(&NamePart::from_word("xx", true, Location::Start))
+        );
+        assert_eq!(
+            "Xx.",
+            canonicalize_prefix(&NamePart::from_word("Xx.", true, Location::Start))
+        );
+    }
+
+    #[test]
+    fn canonicalize_phd_suffix() {
+        assert_eq!(
+            "Ph.D.",
+            canonicalize_suffix(&NamePart::from_word("phd", true, Location::End))
+        );
+        assert_eq!(
+            "Ph.D.",
+            canonicalize_suffix(&NamePart::from_word("Phd", true, Location::End))
+        );
+        assert_eq!(
+            "Ph.D.",
+            canonicalize_suffix(&NamePart::from_word("PHD", true, Location::End))
+        );
+        assert_eq!(
+            "Ph.D.",
+            canonicalize_suffix(&NamePart::from_word("Ph.D.", true, Location::End))
+        );
+    }
+
+    #[test]
+    fn canonicalize_md_suffix() {
+        assert_eq!(
+            "M.D.",
+            canonicalize_suffix(&NamePart::from_word("MD", true, Location::End))
+        );
+        assert_eq!(
+            "M.D.",
+            canonicalize_suffix(&NamePart::from_word("Md", true, Location::End))
+        );
+        assert_eq!(
+            "M.D.",
+            canonicalize_suffix(&NamePart::from_word("md", true, Location::End))
+        );
+        assert_eq!(
+            "M.D.",
+            canonicalize_suffix(&NamePart::from_word("M.D.", true, Location::End))
+        );
+    }
+
+    #[test]
+    fn canonicalize_esq_suffix() {
+        assert_eq!(
+            "Esq.",
+            canonicalize_suffix(&NamePart::from_word("ESQ", true, Location::End))
+        );
+        assert_eq!(
+            "Esq.",
+            canonicalize_suffix(&NamePart::from_word("Esq", true, Location::End))
+        );
+        assert_eq!(
+            "Esq.",
+            canonicalize_suffix(&NamePart::from_word("esq", true, Location::End))
+        );
+        assert_eq!(
+            "Esq.",
+            canonicalize_suffix(&NamePart::from_word("Esquire", true, Location::End))
+        );
+        assert_eq!(
+            "Esq.",
+            canonicalize_suffix(&NamePart::from_word("Esq.", true, Location::End))
+        );
+    }
+
+    #[test]
+    fn canonicalize_unrecognized_suffix() {
+        assert_eq!(
+            "ABC",
+            canonicalize_suffix(&NamePart::from_word("ABC", true, Location::End))
+        );
+        assert_eq!(
+            "Abc",
+            canonicalize_suffix(&NamePart::from_word("Abc", true, Location::End))
+        );
+        assert_eq!(
+            "Abc",
+            canonicalize_suffix(&NamePart::from_word("abc", true, Location::End))
+        );
+        assert_eq!(
+            "A.B.C.",
+            canonicalize_suffix(&NamePart::from_word("A.B.C.", true, Location::End))
+        );
+
+        assert_eq!(
+            "X.X.",
+            canonicalize_suffix(&NamePart::from_word("XX", true, Location::End))
+        );
+        assert_eq!(
+            "X.X.",
+            canonicalize_suffix(&NamePart::from_word("Xx", true, Location::End))
+        );
+        assert_eq!(
+            "X.X.",
+            canonicalize_suffix(&NamePart::from_word("xx", true, Location::End))
+        );
+        assert_eq!(
+            "Xx.",
+            canonicalize_suffix(&NamePart::from_word("Xx.", true, Location::End))
+        );
+    }
 
     #[test]
     fn is_postfix_title_esq() {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -80,11 +80,11 @@ fn parsing() {
             name.middle_initials()
         );
         assert!(
-            name.suffix() == suffix,
+            name.generational_suffix() == suffix,
             "[{}] Expected suffix {:?}, got {:?}",
             input,
             suffix,
-            name.suffix()
+            name.generational_suffix()
         );
     }
 }

--- a/tests/unparseable-names.txt
+++ b/tests/unparseable-names.txt
@@ -29,7 +29,7 @@ johnny y
 #rights now managed by Philosophy Documenation Center
 Campo Gr
 #Professor Steinberg
-Marcin - red. Frybes
+#Marcin - red. Frybes
 #DESY Forschung Hochenergiephysik
 #D. Ould-Ali et
 #et al


### PR DESCRIPTION
Also rename `suffix` to `generational_suffix`, deprecating the former. This changes the JSON serialization output, but as a judgment call I'm not going to call that a backwards-compatibility breakage requiring a major version bump.

Closes https://github.com/djudd/human-name/issues/6