### PR TITLE
Macro cleanup and minor nickname comparison optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "human_name"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "alloc_counter",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "human_name"
-version = "1.1.1"
+version = "1.2.0"
 authors = ["David Judd <david.a.judd@gmail.com>"]
 description = "A library for parsing and comparing human names"
 keywords = ["human", "name", "language", "nlp"]

--- a/src/comparison.rs
+++ b/src/comparison.rs
@@ -188,7 +188,7 @@ impl Name {
                 // without corresponding names, because the logic would have to
                 // be even more complicated.
                 if let NameWordOrInitial::Word(word, _) = my_part {
-                    return eq_or_starts_with!(suffix, word);
+                    return eq_or_starts_with(&suffix, word);
                 } else {
                     return true;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -233,12 +233,4 @@ mod bench {
             black_box(deduped.len())
         })
     }
-
-    #[bench]
-    fn bench_web_match(b: &mut Bencher) {
-        let name = Name::parse("Jane Doe").unwrap();
-        let compare = "janexdoe2005";
-
-        b.iter(|| black_box(name.matches_slug_or_localpart(compare)));
-    }
 }

--- a/src/nickname.rs
+++ b/src/nickname.rs
@@ -369,6 +369,22 @@ mod tests {
             black_box(strip_nickname("James T. 'Jimmy' Kirk").len());
         })
     }
+
+    #[cfg(feature = "bench")]
+    #[bench]
+    fn have_matching_variants_false(b: &mut Bencher) {
+        b.iter(|| {
+            black_box(have_matching_variants("David", "Daniel"));
+        })
+    }
+
+    #[cfg(feature = "bench")]
+    #[bench]
+    fn have_matching_variants_true(b: &mut Bencher) {
+        b.iter(|| {
+            black_box(have_matching_variants("David", "Dave"));
+        })
+    }
 }
 
 static NAMES_BY_NICK_PREFIX: phf::Map<&'static str, &'static [&'static str]> = phf_map! {
@@ -559,7 +575,6 @@ static NAMES_BY_NICK_PREFIX: phf::Map<&'static str, &'static [&'static str]> = p
     "Vann" => &[ "Vanessa" ],
     "Verg" => &[ "Virginia" ],
     "Vess" => &[ "Sylvester" ],
-    "Vic" => &[ "Lewvisa" ],
     "Vin" => &[ "Lavinia" ],
     "Vonn" => &[ "Veronica" ],
     "Wend" => &[ "Gwendolyn" ],

--- a/src/nickname.rs
+++ b/src/nickname.rs
@@ -183,67 +183,78 @@ pub fn have_matching_variants(original_a: &str, original_b: &str) -> bool {
     })
 }
 
+#[inline]
 fn variants_match(a: &str, b: &str) -> bool {
-    have_prefix_match(a, b)
-        || is_final_syllables_of(a, b)
-        || is_final_syllables_of(b, a)
+    let (longer, shorter) = if a.len() >= b.len() { (a, b) } else { (b, a) };
+
+    have_prefix_match(longer, shorter)
+        || is_final_syllables_of(shorter, longer)
         || matches_without_diminutive(a, b)
         || matches_without_diminutive(b, a)
 }
 
-#[allow(clippy::needless_bool)]
-#[allow(clippy::if_same_then_else)]
-fn have_prefix_match(a: &str, b: &str) -> bool {
-    if eq_or_starts_with!(a, b) {
-        // Exception: Case where one variant is a feminized version of the other
-        if a.len() == b.len() + 1 && a.ends_with('a') {
-            false
-        } else if b.len() == a.len() + 1 && b.ends_with('a') {
-            false
-        } else {
-            true
-        }
-    } else {
-        false
-    }
+#[inline]
+fn have_prefix_match(longer: &str, shorter: &str) -> bool {
+    eq_or_starts_with(longer, shorter) && !is_simple_feminization(longer, shorter)
 }
 
-#[allow(clippy::if_same_then_else)]
+#[inline]
+fn is_simple_feminization(longer: &str, shorter: &str) -> bool {
+    longer.len() == shorter.len() + 1 && longer.ends_with('a')
+}
+
+#[inline]
 fn matches_without_diminutive(a: &str, b: &str) -> bool {
-    if DIMINUTIVE_EXCEPTIONS.contains(a) {
-        false
-    } else if a.len() > 2
+    matches_without_y_or_e(a, b)
+        || matches_without_ie_or_ey(a, b)
+        || matches_without_ita_or_ina(a, b)
+        || matches_without_ito(a, b)
+}
+
+#[inline]
+fn matches_without_y_or_e(a: &str, b: &str) -> bool {
+    a.len() > 2
         && b.len() >= a.len() - 1
         && (a.ends_with('y') || a.ends_with('e'))
-        && eq_or_starts_with!(a[0..a.len() - 1], b)
-    {
-        true
-    } else if a.len() > 4
+        && matches_after_removing_diminutive(a, b, 1)
+}
+
+#[inline]
+fn matches_without_ie_or_ey(a: &str, b: &str) -> bool {
+    a.len() > 4
         && b.len() >= a.len() - 2
         && (a.ends_with("ie") || a.ends_with("ey"))
-        && eq_or_starts_with!(a[0..a.len() - 2], b)
-    {
-        true
-    } else if a.len() > 5
+        && matches_after_removing_diminutive(a, b, 2)
+}
+
+#[inline]
+fn matches_without_ita_or_ina(a: &str, b: &str) -> bool {
+    a.len() > 5
         && b.len() >= a.len() - 3
         && b.ends_with('a')
         && (a.ends_with("ita") || a.ends_with("ina"))
-        && eq_or_starts_with!(a[0..a.len() - 3], b)
-    {
-        true
-    } else {
-        a.len() > 5
-            && b.len() >= a.len() - 3
-            && b.ends_with('o')
-            && a.ends_with("ito")
-            && eq_or_starts_with!(a[0..a.len() - 3], b)
-    }
+        && matches_after_removing_diminutive(a, b, 3)
 }
 
+#[inline]
+fn matches_without_ito(a: &str, b: &str) -> bool {
+    a.len() > 5
+        && b.len() >= a.len() - 3
+        && b.ends_with('o')
+        && a.ends_with("ito")
+        && matches_after_removing_diminutive(a, b, 3)
+}
+
+#[inline]
+fn matches_after_removing_diminutive(a: &str, b: &str, diminutive_len: usize) -> bool {
+    eq_or_starts_with(&a[0..a.len() - diminutive_len], b) && !DIMINUTIVE_EXCEPTIONS.contains(a)
+}
+
+#[inline]
 fn is_final_syllables_of(needle: &str, haystack: &str) -> bool {
     if needle.len() == haystack.len() - 1
         && !starts_with_consonant(haystack)
-        && eq_or_ends_with!(needle, haystack)
+        && eq_or_ends_with(needle, haystack)
     {
         true
     } else if haystack.len() < 4 || needle.len() < 2 || needle.len() > haystack.len() - 2 {
@@ -252,7 +263,7 @@ fn is_final_syllables_of(needle: &str, haystack: &str) -> bool {
         || needle.starts_with("Ann")
         || haystack.starts_with("Mary")
     {
-        eq_or_ends_with!(needle, haystack) && !FINAL_SYLLABLES_EXCEPTIONS.contains(needle)
+        eq_or_ends_with(needle, haystack) && !FINAL_SYLLABLES_EXCEPTIONS.contains(needle)
     } else {
         false
     }
@@ -319,6 +330,22 @@ mod tests {
         assert!(!have_matching_variants("John", "Nathan"));
         assert!(!have_matching_variants("Mary", "Margeret"));
         assert!(!have_matching_variants("Annette", "Johanna"));
+    }
+
+    #[test]
+    fn variants() {
+        assert_eq!(
+            vec!["Ada", "Adelaide", "Adele", "Adelina", "Adeline"],
+            NameVariants::for_name("Ada")
+                .iter_with_original()
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            vec!["Adele"],
+            NameVariants::for_name("Adele")
+                .iter_with_original()
+                .collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -264,52 +264,46 @@ pub fn has_sequential_alphas(word: &str) -> bool {
     false
 }
 
-#[macro_export]
-macro_rules! eq_or_starts_with {
-    ($a:expr, $b:expr) => {{
-        let mut chars_a = $a.chars().filter_map(lowercase_if_alpha);
-        let mut chars_b = $b.chars().filter_map(lowercase_if_alpha);
-        let result;
+pub fn eq_or_starts_with(a: &str, b: &str) -> bool {
+    let mut chars_a = a.chars().filter_map(lowercase_if_alpha);
+    let mut chars_b = b.chars().filter_map(lowercase_if_alpha);
+    let result;
 
-        loop {
-            let a = chars_a.next();
-            let b = chars_b.next();
+    loop {
+        let a = chars_a.next();
+        let b = chars_b.next();
 
-            if a.is_none() || b.is_none() {
-                result = true;
-                break;
-            } else if a != b {
-                result = false;
-                break;
-            }
+        if a.is_none() || b.is_none() {
+            result = true;
+            break;
+        } else if a != b {
+            result = false;
+            break;
         }
+    }
 
-        result
-    }};
+    result
 }
 
-#[macro_export]
-macro_rules! eq_or_ends_with {
-    ($needle:expr, $haystack:expr) => {{
-        let mut n_chars = $needle.chars().rev().filter_map(lowercase_if_alpha);
-        let mut h_chars = $haystack.chars().rev().filter_map(lowercase_if_alpha);
-        let result;
+pub fn eq_or_ends_with(needle: &str, haystack: &str) -> bool {
+    let mut n_chars = needle.chars().rev().filter_map(lowercase_if_alpha);
+    let mut h_chars = haystack.chars().rev().filter_map(lowercase_if_alpha);
+    let result;
 
-        loop {
-            let n = n_chars.next();
-            let h = h_chars.next();
+    loop {
+        let n = n_chars.next();
+        let h = h_chars.next();
 
-            if n.is_none() {
-                result = true;
-                break;
-            } else if n != h {
-                result = false;
-                break;
-            }
+        if n.is_none() {
+            result = true;
+            break;
+        } else if n != h {
+            result = false;
+            break;
         }
+    }
 
-        result
-    }};
+    result
 }
 
 #[cfg(test)]

--- a/src/web_match.rs
+++ b/src/web_match.rs
@@ -186,7 +186,7 @@ impl Name {
 
         if let Some(ref name) = given_names {
             // Allow just given name, or partial given name, as part
-            if name.len() >= part.len() && eq_or_starts_with!(part, name) {
+            if name.len() >= part.len() && eq_or_starts_with(part, name) {
                 return true;
             }
         } else if allow_unknowns {
@@ -199,7 +199,7 @@ impl Name {
 
         if self.middle_initials().is_some() {
             // Allow just initials, or partial initials, as part
-            if self.initials().len() >= part.len() && eq_or_starts_with!(part, self.initials()) {
+            if self.initials().len() >= part.len() && eq_or_starts_with(part, self.initials()) {
                 return true;
             }
         } else if allow_unknowns {
@@ -212,15 +212,14 @@ impl Name {
         }
 
         if let Some(ref name) = given_names {
-            if part.len() > name.len() && eq_or_starts_with!(part, name) {
+            if part.len() > name.len() && eq_or_starts_with(part, name) {
                 let remainder = &part[name.len()..];
 
                 // Allow given name *plus* middle initials as part (with heuristic
                 // when middle initials are unknown and surname matched exactly,
                 // assuming maximum likely number of middle initials is two)
                 if let Some(initials) = self.middle_initials() {
-                    if initials.len() >= remainder.len() && eq_or_starts_with!(remainder, initials)
-                    {
+                    if initials.len() >= remainder.len() && eq_or_starts_with(remainder, initials) {
                         return true;
                     }
                 } else if allow_unknowns && remainder.len() < 3 {
@@ -230,12 +229,12 @@ impl Name {
         }
 
         if let Some(initials) = self.middle_initials() {
-            if part.len() > initials.len() && eq_or_ends_with!(initials, part) {
+            if part.len() > initials.len() && eq_or_ends_with(initials, part) {
                 let remainder = &part[0..part.len() - initials.len()];
 
                 // Allow partial given name, plus known middle initials, as part
                 if let Some(name) = self.given_name() {
-                    if eq_or_starts_with!(remainder, name) {
+                    if eq_or_starts_with(remainder, name) {
                         return true;
                     }
                 }


### PR DESCRIPTION
`eq_or_starts_with` and `eq_or_ends_with` had no particular reason to be macros and this was probably just causing a bit of bloat. Having them be macros seems to have had the unintended side effect of exposing them publicly, though they were not documented and it seems unlikely they were used. Technically this is a compatibility breakage but since it's unlikely to matter I'm only bumping the minor version.

This also optimizes nickname comparison a bit by moving a relatively pricy phf_set lookup to be the last condition checked in a sequence.