### PR TITLE
Shrink struct sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "human_name"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "alloc_counter",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "human_name"
-version = "1.3.2"
+version = "1.3.3"
 authors = ["David Judd <cargo@davidjudd.net>"]
 description = "A library for parsing and comparing human names"
 keywords = ["human", "name", "language", "nlp"]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "human_name"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "libc",
  "phf",

--- a/src/comparison.rs
+++ b/src/comparison.rs
@@ -294,10 +294,11 @@ impl Name {
     }
 
     fn missing_given_name(&self) -> bool {
-        self.given_names_in_initials()
-            .get(0)
-            .map(|loc| loc.range().start > 0)
-            .unwrap_or(true)
+        if let Some(loc) = self.given_names_in_initials().get(0) {
+            loc.range().start > 0
+        } else {
+            true
+        }
     }
 
     fn missing_any_name(&self) -> bool {

--- a/src/comparison.rs
+++ b/src/comparison.rs
@@ -116,7 +116,7 @@ impl Name {
         GivenNamesOrInitials {
             initials: self.initials().chars().enumerate(),
             known_names: self.given_iter(),
-            known_name_indices: self.word_indices_in_initials().iter().peekable(),
+            known_name_indices: self.locations_in_initials().iter().peekable(),
         }
     }
 
@@ -285,7 +285,7 @@ impl Name {
     }
 
     fn missing_given_name(&self) -> bool {
-        if let Some(&Range { start, .. }) = self.word_indices_in_initials().get(0) {
+        if let Some(&Range { start, .. }) = self.locations_in_initials().get(0) {
             start > 0
         } else {
             true
@@ -299,7 +299,7 @@ impl Name {
 
         let mut prev = 0;
 
-        for &Range { start, end } in self.word_indices_in_initials() {
+        for &Range { start, end } in self.locations_in_initials() {
             if start > prev {
                 return true;
             } else {

--- a/src/comparison.rs
+++ b/src/comparison.rs
@@ -116,7 +116,7 @@ impl Name {
         GivenNamesOrInitials {
             initials: self.initials().chars().enumerate(),
             known_names: self.given_iter(),
-            known_name_indices: self.word_indices_in_initials.iter().peekable(),
+            known_name_indices: self.word_indices_in_initials().iter().peekable(),
         }
     }
 
@@ -285,7 +285,7 @@ impl Name {
     }
 
     fn missing_given_name(&self) -> bool {
-        if let Some(&Range { start, .. }) = self.word_indices_in_initials.get(0) {
+        if let Some(&Range { start, .. }) = self.word_indices_in_initials().get(0) {
             start > 0
         } else {
             true
@@ -299,7 +299,7 @@ impl Name {
 
         let mut prev = 0;
 
-        for &Range { start, end } in self.word_indices_in_initials.iter() {
+        for &Range { start, end } in self.word_indices_in_initials() {
             if start > prev {
                 return true;
             } else {

--- a/src/comparison.rs
+++ b/src/comparison.rs
@@ -126,7 +126,7 @@ impl Name {
         }
 
         // Unless both versions of the name have given or middle names, we're done
-        if self.surname_index == 0 || other.surname_index == 0 {
+        if self.surname_index_in_words() == 0 || other.surname_index_in_words() == 0 {
             return true;
         }
 
@@ -291,7 +291,7 @@ impl Name {
     }
 
     fn missing_any_name(&self) -> bool {
-        if self.surname_index == 0 {
+        if self.surname_index_in_words() == 0 {
             return true;
         }
 
@@ -305,7 +305,7 @@ impl Name {
             }
         }
 
-        self.surname_index > prev
+        self.surname_index_in_words() > prev.into()
     }
 
     #[inline]

--- a/src/comparison.rs
+++ b/src/comparison.rs
@@ -76,7 +76,9 @@ impl Name {
             && self.suffix_consistent(other)
     }
 
-    #[inline]
+    // Not clear why we have to `always` here but the performance difference is detectable
+    // and there's only one caller (though we call this twice)
+    #[inline(always)]
     fn split_initials(&self) -> (char, usize) {
         let mut initials = self.initials().chars();
         let first = initials.next().unwrap();
@@ -112,7 +114,7 @@ impl Name {
     #[inline]
     fn given_names_or_initials(&self) -> GivenNamesOrInitials {
         GivenNamesOrInitials {
-            initials: self.initials.chars().enumerate(),
+            initials: self.initials().chars().enumerate(),
             known_names: self.given_iter(),
             known_name_indices: self.word_indices_in_initials.iter().peekable(),
         }
@@ -406,9 +408,10 @@ impl Name {
 
     #[inline]
     fn suffix_consistent(&self, other: &Name) -> bool {
-        self.generation_from_suffix.is_none()
-            || other.generation_from_suffix.is_none()
-            || self.generation_from_suffix == other.generation_from_suffix
+        match (self.generational_suffix(), other.generational_suffix()) {
+            (Some(mine), Some(theirs)) => mine == theirs,
+            _ => true,
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,8 +98,8 @@ pub struct Name {
 
 #[derive(Clone, Debug)]
 struct Honorifics {
-    prefix: Option<String>,
-    suffix: Option<String>,
+    prefix: Option<Box<str>>,
+    suffix: Option<Box<str>>,
 }
 
 impl Name {
@@ -229,8 +229,12 @@ impl Name {
         debug_assert!(!initials.is_empty(), "Initials are empty!");
 
         let honorifics = {
-            let prefix = parsed.honorific_prefix().map(Cow::into_owned);
-            let suffix = parsed.honorific_suffix().map(Cow::into_owned);
+            let prefix = parsed
+                .honorific_prefix()
+                .map(|s| s.into_owned().into_boxed_str());
+            let suffix = parsed
+                .honorific_suffix()
+                .map(|s| s.into_owned().into_boxed_str());
 
             if prefix.is_some() || suffix.is_some() {
                 Some(Box::new(Honorifics { prefix, suffix }))
@@ -651,6 +655,7 @@ mod tests {
     #[test]
     fn struct_size() {
         assert_eq!(88, std::mem::size_of::<Name>());
+        assert_eq!(32, std::mem::size_of::<Honorifics>());
     }
 
     #[test]

--- a/src/title.rs
+++ b/src/title.rs
@@ -1052,7 +1052,7 @@ mod tests {
             "Jane Doe",
             parts[prefix..]
                 .iter()
-                .fold("".to_string(), |s, ref p| s + " " + p.word)
+                .fold("".to_string(), |s, p| s + " " + p.word)
                 .trim()
         );
     }
@@ -1066,7 +1066,7 @@ mod tests {
             "Jane Doe",
             parts[prefix..]
                 .iter()
-                .fold("".to_string(), |s, ref p| s + " " + p.word)
+                .fold("".to_string(), |s, p| s + " " + p.word)
                 .trim()
         );
     }
@@ -1080,7 +1080,7 @@ mod tests {
             "Jane Doe",
             parts[prefix..]
                 .iter()
-                .fold("".to_string(), |s, ref p| s + " " + p.word)
+                .fold("".to_string(), |s, p| s + " " + p.word)
                 .trim()
         );
     }
@@ -1094,7 +1094,7 @@ mod tests {
             "Jane Doe",
             parts[prefix..]
                 .iter()
-                .fold("".to_string(), |s, ref p| s + " " + p.word)
+                .fold("".to_string(), |s, p| s + " " + p.word)
                 .trim()
         );
     }
@@ -1108,7 +1108,7 @@ mod tests {
             "Jane Doe",
             parts[prefix..]
                 .iter()
-                .fold("".to_string(), |s, ref p| s + " " + p.word)
+                .fold("".to_string(), |s, p| s + " " + p.word)
                 .trim()
         );
     }
@@ -1121,7 +1121,7 @@ mod tests {
             "Doe",
             parts[prefix..]
                 .iter()
-                .fold("".to_string(), |s, ref p| s + " " + p.word)
+                .fold("".to_string(), |s, p| s + " " + p.word)
                 .trim()
         );
     }

--- a/src/web_match.rs
+++ b/src/web_match.rs
@@ -176,9 +176,9 @@ impl Name {
 
     fn matches_remaining_name_parts(&self, part: &str, allow_unknowns: bool) -> bool {
         let lower_first_initial = self.first_initial().to_lowercase().next().unwrap();
-        let given_names: Option<Cow<str>> = if self.surname_index == 1 {
+        let given_names: Option<Cow<str>> = if self.surname_index_in_words() == 1 {
             self.given_name().map(Cow::Borrowed)
-        } else if self.surname_index > 0 {
+        } else if self.surname_index_in_words() > 0 {
             Some(self.given_iter().join())
         } else {
             None

--- a/src/web_match.rs
+++ b/src/web_match.rs
@@ -70,7 +70,7 @@ impl Name {
         }
 
         // Special case: Full initials
-        let full_initials_len = self.initials().len() + self.surname_words();
+        let full_initials_len = usize::from(self.initials_len + self.surname_words);
         if full_initials_len > 2 && normed.len() == full_initials_len {
             let mut initials = String::with_capacity(full_initials_len);
             initials.extend(self.initials().chars().flat_map(char::to_lowercase));
@@ -87,7 +87,7 @@ impl Name {
 
         // Special case: Given name plus surname initial
         if let Some(name) = self.given_name() {
-            let name_and_initial_len = name.len() + self.surname_words();
+            let name_and_initial_len = name.len() + usize::from(self.surname_words);
             if normed.len() == name_and_initial_len {
                 let mut name_and_initial = String::with_capacity(name_and_initial_len);
                 name_and_initial.extend(name.chars().flat_map(char::to_lowercase));
@@ -176,9 +176,9 @@ impl Name {
 
     fn matches_remaining_name_parts(&self, part: &str, allow_unknowns: bool) -> bool {
         let lower_first_initial = self.first_initial().to_lowercase().next().unwrap();
-        let given_names: Option<Cow<str>> = if self.given_name_locations.len() == 1 {
+        let given_names: Option<Cow<str>> = if self.given_name_words == 1 {
             self.given_name().map(Cow::Borrowed)
-        } else if !self.given_name_locations.is_empty() {
+        } else if self.given_name_words > 0 {
             Some(self.given_iter().join())
         } else {
             None

--- a/src/web_match.rs
+++ b/src/web_match.rs
@@ -176,9 +176,9 @@ impl Name {
 
     fn matches_remaining_name_parts(&self, part: &str, allow_unknowns: bool) -> bool {
         let lower_first_initial = self.first_initial().to_lowercase().next().unwrap();
-        let given_names: Option<Cow<str>> = if self.surname_index_in_words() == 1 {
+        let given_names: Option<Cow<str>> = if self.given_name_locations.len() == 1 {
             self.given_name().map(Cow::Borrowed)
-        } else if self.surname_index_in_words() > 0 {
+        } else if !self.given_name_locations.is_empty() {
             Some(self.given_iter().join())
         } else {
             None

--- a/src/word.rs
+++ b/src/word.rs
@@ -76,14 +76,14 @@ pub struct WordIndices(SmallVec<[Range<u16>; 4]>);
 
 impl WordIndices {
     #[inline]
-    pub fn new() -> Self {
-        WordIndices(SmallVec::new())
-    }
-
-    #[inline]
     pub fn push(&mut self, indices: Range<usize>) {
         self.0
             .push(indices.start.try_into().unwrap()..indices.end.try_into().unwrap())
+    }
+
+    #[inline]
+    pub fn with_capacity(size: usize) -> WordIndices {
+        WordIndices(SmallVec::with_capacity(size))
     }
 
     #[inline]

--- a/src/word.rs
+++ b/src/word.rs
@@ -18,6 +18,7 @@ impl Location {
         }
     }
 
+    #[inline]
     pub fn new(range: Range<usize>) -> Option<Self> {
         let start = range.start.try_into().ok()?;
         let end = range.end.try_into().ok()?;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -22,26 +22,26 @@ fn parsing() {
     for line in reader.lines() {
         let line: String = line.ok().unwrap().nfkd().collect();
 
-        if line.starts_with("#") || !line.contains("|") {
+        if line.starts_with('#') || !line.contains('|') {
             continue;
         }
 
-        let parts: Vec<&str> = line.split("|").collect();
+        let parts: Vec<&str> = line.split('|').collect();
         let input = parts[0];
         let surname = parts[1];
         let given_name = parts[2];
         let middle_names = parts[3];
-        let first_initial = parts[4].chars().nth(0).unwrap();
+        let first_initial = parts[4].chars().next().unwrap();
         let middle_initials = parts[5];
         let suffix = parts[6];
 
         let name = human_name::Name::parse(input);
-        assert!(!name.is_none(), "[{}] Could not parse!", input);
+        assert!(name.is_some(), "[{}] Could not parse!", input);
 
-        let given_name = none_if_empty(&given_name);
-        let middle_names = none_if_empty(&middle_names);
-        let middle_initials = none_if_empty(&middle_initials);
-        let suffix = none_if_empty(&suffix);
+        let given_name = none_if_empty(given_name);
+        let middle_names = none_if_empty(middle_names);
+        let middle_initials = none_if_empty(middle_initials);
+        let suffix = none_if_empty(suffix);
 
         let name = name.unwrap();
         assert!(
@@ -97,7 +97,7 @@ fn unparseable() {
     for line in reader.lines() {
         let line = line.ok().unwrap();
 
-        if line.starts_with("#") {
+        if line.starts_with('#') {
             continue;
         }
 
@@ -119,7 +119,7 @@ fn equality() {
     for line in reader.lines() {
         let line = line.ok().unwrap();
 
-        if line.starts_with("#") {
+        if line.starts_with('#') {
             continue;
         }
 
@@ -128,8 +128,8 @@ fn equality() {
         let b = parts[1];
         let expect = parts[2];
 
-        let parsed_a = human_name::Name::parse(&a);
-        let parsed_b = human_name::Name::parse(&b);
+        let parsed_a = human_name::Name::parse(a);
+        let parsed_b = human_name::Name::parse(b);
 
         assert!(parsed_a.is_some(), "{} was not parsed", a);
         assert!(parsed_b.is_some(), "{} was not parsed", b);
@@ -179,7 +179,7 @@ fn web_match() {
     for line in reader.lines() {
         let line = line.ok().unwrap();
 
-        if line.starts_with("#") {
+        if line.starts_with('#') {
             continue;
         }
 
@@ -205,7 +205,7 @@ fn web_nonmatch() {
     for line in reader.lines() {
         let line = line.ok().unwrap();
 
-        if line.starts_with("#") {
+        if line.starts_with('#') {
             continue;
         }
 


### PR DESCRIPTION
Shrink struct sizes, most importantly shrinking the size of the Name struct by only creating one SmallString (which concatenates the name display text and the initials) and one SmallVec (which concatenates the ranges of words in the text and in the initials).

Includes a fair amount of other refactoring and cleanup to (a) keep things relatively readable given the less natural data structure, (b) preserve performance in benchmarks, and (c) satisfy clippy.