### PR TITLE
Replace unmaintained smallstr with compact_str

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,10 +24,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
 
 [[package]]
 name = "crossbeam-utils"
@@ -43,13 +66,13 @@ name = "human_name"
 version = "2.0.2"
 dependencies = [
  "alloc_counter",
+ "compact_str",
  "crossbeam-utils",
  "libc",
  "phf",
  "phf_codegen",
  "serde",
  "serde_json",
- "smallstr",
  "smallvec",
  "unicode-case-mapping",
  "unicode-normalization",
@@ -147,6 +170,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,19 +219,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
-name = "smallstr"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b1aefdf380735ff8ded0b15f31aab05daf1f70216c01c02a12926badd1df9d"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ phf = "0.11"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 smallvec = { features = ["union"], version = "1.9" }
-smallstr = "0.3"
+compact_str = { version = "0.7.1", features = ["serde"] }
 
 [dev-dependencies]
 alloc_counter = "0.0"

--- a/build.rs
+++ b/build.rs
@@ -117,7 +117,7 @@ where
     for (k, v) in map {
         builder.entry(k.to_string(), &transform(v));
     }
-    fs::write(&output, format!("{}", builder.build()))?;
+    fs::write(output, format!("{}", builder.build()))?;
     Ok(())
 }
 
@@ -126,7 +126,7 @@ fn write_set(output: &Path, set: &[String]) -> Result<()> {
     for v in set {
         builder.entry(v);
     }
-    fs::write(&output, format!("{}", builder.build()))?;
+    fs::write(output, format!("{}", builder.build()))?;
     Ok(())
 }
 

--- a/src/case.rs
+++ b/src/case.rs
@@ -106,9 +106,7 @@ impl DoubleEndedIterator for CaseMapping {
 
 impl ExactSizeIterator for CaseMapping {}
 
-fn casefolded_alphas(
-    text: &str,
-) -> impl Iterator<Item = char> + std::iter::DoubleEndedIterator + '_ {
+fn casefolded_alphas(text: &str) -> impl std::iter::DoubleEndedIterator<Item = char> + '_ {
     // It would be more correct to use unicode case folding here,
     // but unicode-case-mapping 0.4 only supports simple case folding
     // and not multi-character folding, which isn't really better.

--- a/src/comparison.rs
+++ b/src/comparison.rs
@@ -289,7 +289,7 @@ impl Name {
     }
 
     fn missing_given_name(&self) -> bool {
-        if let Some(loc) = self.given_names_in_initials().get(0) {
+        if let Some(loc) = self.given_names_in_initials().first() {
             loc.range().start > 0
         } else {
             true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,7 +308,7 @@ impl Name {
     /// assert!(name.goes_by_middle_name());
     /// ```
     pub fn goes_by_middle_name(&self) -> bool {
-        if let Some(loc) = self.given_names_in_initials().get(0) {
+        if let Some(loc) = self.given_names_in_initials().first() {
             loc.range().start > 0
         } else {
             false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
 #![cfg_attr(feature = "bench", feature(test))]
 
 extern crate crossbeam_utils;
-extern crate smallstr;
 extern crate smallvec;
 extern crate unicode_normalization;
 extern crate unicode_segmentation;
@@ -45,8 +44,8 @@ mod serialization;
 
 use crate::decomposition::normalize_nfkd_whitespace;
 use crate::word::{Location, Words};
+use compact_str::CompactString;
 use crossbeam_utils::atomic::AtomicCell;
-use smallstr::SmallString;
 use smallvec::SmallVec;
 use std::borrow::Cow;
 use std::collections::hash_map::DefaultHasher;
@@ -84,7 +83,7 @@ pub const MAX_SEGMENTS: usize = parse::MAX_WORDS;
 /// the same person (see docs on `consistent_with` for details).
 #[derive(Debug)]
 pub struct Name {
-    text: SmallString<[u8; 32]>, // stores concatenation of display_full() and initials()
+    text: CompactString, // stores concatenation of display_full() and initials()
     locations: SmallVec<[Location; 6]>, // stores concatenation of word locations in full text and given name locations in initials
     given_name_words: u8,               // support no more than 256
     surname_words: u8,                  // support no more than 256
@@ -192,8 +191,8 @@ impl Name {
         let words = parsed.words();
         let surname_index = parsed.surname_index;
 
-        let mut text = SmallString::with_capacity(name_len + surname_index);
-        let mut initials: SmallString<[u8; 16]> = SmallString::with_capacity(surname_index);
+        let mut text = CompactString::with_capacity(name_len + surname_index);
+        let mut initials = CompactString::with_capacity(surname_index);
 
         let mut locations = SmallVec::with_capacity(words.len() + surname_index);
         let mut locations_in_initials: SmallVec<[Location; 4]> =
@@ -707,7 +706,7 @@ mod tests {
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     #[test]
     fn struct_size() {
-        assert_eq!(96, std::mem::size_of::<Name>());
+        assert_eq!(80, std::mem::size_of::<Name>());
         assert_eq!(32, std::mem::size_of::<Honorifics>());
     }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -25,7 +25,7 @@ impl<'a> Name<'a> {
             0 => None,
             1 => self
                 .reversed_prefixes
-                .get(0)
+                .first()
                 .map(title::canonicalize_prefix),
             _ => Some(Cow::Owned(
                 self.reversed_prefixes
@@ -43,7 +43,7 @@ impl<'a> Name<'a> {
             0 => None,
             1 => self
                 .honorific_suffixes
-                .get(0)
+                .first()
                 .map(title::canonicalize_suffix),
             _ => Some(Cow::Owned(
                 self.honorific_suffixes
@@ -311,8 +311,7 @@ impl<'a> ParseOp<'a> {
             self.surname_index = given_middle_or_postfix_words.len();
 
             self.words.reserve(given_middle_or_postfix_words.len());
-            self.words
-                .insert_many(0, given_middle_or_postfix_words.into_iter());
+            self.words.insert_many(0, given_middle_or_postfix_words);
         }
     }
 

--- a/src/surname.rs
+++ b/src/surname.rs
@@ -53,67 +53,67 @@ mod tests {
     #[test]
     fn one_word() {
         let parts: Vec<_> = NamePart::all_from_text("Doe", true, Location::Start).collect();
-        assert_eq!(0, find_surname_index(&*parts));
+        assert_eq!(0, find_surname_index(&parts));
     }
 
     #[test]
     fn two_words() {
         let parts: Vec<_> = NamePart::all_from_text("Jane Doe", true, Location::Start).collect();
-        assert_eq!(1, find_surname_index(&*parts));
+        assert_eq!(1, find_surname_index(&parts));
     }
 
     #[test]
     fn three_words() {
         let parts: Vec<_> =
             NamePart::all_from_text("Jane Emily Doe", true, Location::Start).collect();
-        assert_eq!(2, find_surname_index(&*parts));
+        assert_eq!(2, find_surname_index(&parts));
     }
 
     #[test]
     fn conjunction_after_nothing() {
         let parts: Vec<_> = NamePart::all_from_text("y Velazquez", true, Location::Start).collect();
-        assert_eq!(1, find_surname_index(&*parts));
+        assert_eq!(1, find_surname_index(&parts));
     }
 
     #[test]
     fn conjunction_after_one() {
         let parts: Vec<_> =
             NamePart::all_from_text("Rodrigo y Velazquez", true, Location::Start).collect();
-        assert_eq!(0, find_surname_index(&*parts));
+        assert_eq!(0, find_surname_index(&parts));
     }
 
     #[test]
     fn conjunction_after_two() {
         let parts: Vec<_> =
             NamePart::all_from_text("Jane Rodrigo y Velazquez", true, Location::Start).collect();
-        assert_eq!(1, find_surname_index(&*parts));
+        assert_eq!(1, find_surname_index(&parts));
     }
 
     #[test]
     fn particle_after_nothing() {
         let parts: Vec<_> =
             NamePart::all_from_text("Abd al-Qader", true, Location::Start).collect();
-        assert_eq!(0, find_surname_index(&*parts));
+        assert_eq!(0, find_surname_index(&parts));
     }
 
     #[test]
     fn particle_after_one() {
         let parts: Vec<_> =
             NamePart::all_from_text("Jane Abd al-Qader", true, Location::Start).collect();
-        assert_eq!(1, find_surname_index(&*parts));
+        assert_eq!(1, find_surname_index(&parts));
     }
 
     #[test]
     fn particle_and_conjunction() {
         let parts: Vec<_> =
             NamePart::all_from_text("Alejandro de Aza y Cabra", true, Location::Start).collect();
-        assert_eq!(1, find_surname_index(&*parts));
+        assert_eq!(1, find_surname_index(&parts));
     }
 
     #[test]
     fn conjunction_and_particle() {
         let parts: Vec<_> =
             NamePart::all_from_text("Alejandro Cabra y de Aza", true, Location::Start).collect();
-        assert_eq!(1, find_surname_index(&*parts));
+        assert_eq!(1, find_surname_index(&parts));
     }
 }

--- a/src/transliterate.rs
+++ b/src/transliterate.rs
@@ -4,7 +4,7 @@ use unidecode::unidecode_char;
 #[inline]
 fn transliterate(c: char) -> Chars<'static> {
     let s = unidecode_char(c);
-    if s.is_empty() {}
+    if s.is_empty() {};
     // We should maybe use unicode case folding here as an initial pass,
     // but without a concrete motivating case (yet) it doesn't seem worth
     // the cost.

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -128,8 +128,8 @@ fn equality() {
         let b = parts[1];
         let expect = parts[2];
 
-        let parsed_a = human_name::Name::parse(a).expect(&format!("{} was not parsed", a));
-        let parsed_b = human_name::Name::parse(b).expect(&format!("{} was not parsed", b));
+        let parsed_a = human_name::Name::parse(a).unwrap_or_else(|| panic!("{} was not parsed", a));
+        let parsed_b = human_name::Name::parse(b).unwrap_or_else(|| panic!("{} was not parsed", b));
 
         if expect == "==" {
             assert!(


### PR DESCRIPTION
The [`smallstr`](https://github.com/murarth/smallstr) crate appears to be largely unmaintained (and its author is mostly inactive). Considering it's a potential vulnerability, we can practically drop-in replace it with [`compact_str`](https://crates.io/crates/compact_str). `compact_str` stores up to 24 bytes on the stack.

I also updated the `struct_size` test to reflect the new size and fixed most clippy warnings.

Let me know if there's anything else you'd like me to do :)