### PR TITLE
Replace unmaintained unidecode with deunicode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,12 +62,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "deunicode"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6e854126756c496b8c81dec88f9a706b15b875c5849d4097a3854476b9fdf94"
+
+[[package]]
 name = "human_name"
 version = "2.0.3"
 dependencies = [
  "alloc_counter",
  "compact_str",
  "crossbeam-utils",
+ "deunicode",
  "libc",
  "phf",
  "phf_codegen",
@@ -77,7 +84,6 @@ dependencies = [
  "unicode-case-mapping",
  "unicode-normalization",
  "unicode-segmentation",
- "unidecode",
 ]
 
 [[package]]
@@ -282,9 +288,3 @@ name = "unicode-segmentation"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
-
-[[package]]
-name = "unidecode"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402bb19d8e03f1d1a7450e2bd613980869438e0666331be3e073089124aa1adc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,13 @@ crossbeam-utils = "0.8"
 unicode-segmentation = "1.9"
 unicode-normalization = "0.1"
 unicode-case-mapping = "0.4"
-unidecode = "0.3"
 libc = { version = "0.2", optional = true }
 phf = "0.11"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 smallvec = { features = ["union"], version = "1.9" }
 compact_str = { version = "0.7.1", features = ["serde"] }
+deunicode = "1.4.3"
 
 [dev-dependencies]
 alloc_counter = "0.0"

--- a/src/comparison.rs
+++ b/src/comparison.rs
@@ -43,7 +43,7 @@ impl Name {
     /// names and/or suffixes are present in both names, they must match as well.
     ///
     /// Transliterates everything to ASCII before comparison using the naive
-    /// algorithm of [unidecode](https://github.com/chowdhurya/rust-unidecode/)
+    /// algorithm of [deunicode](https://github.com/kornelski/deunicode/blob/main/README.md)
     /// (which ignores context), and ignores case, accents and combining marks.
     ///
     /// In the case of given and middle names, allows one name to be a prefix of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,10 @@
 #![cfg_attr(feature = "bench", feature(test))]
 
 extern crate crossbeam_utils;
+extern crate deunicode;
 extern crate smallvec;
 extern crate unicode_normalization;
 extern crate unicode_segmentation;
-extern crate unidecode;
 
 #[cfg(test)]
 #[cfg(feature = "bench")]


### PR DESCRIPTION
The [`unidecode`](https://crates.io/crates/unidecode) crate appears to be unmaintained. For similar reasons as in #38, we can replace this dependency with the [`deunicode`](https://crates.io/crates/deunicode) crate that explicitly positions itself as an alternative.

This currently breaks the `emojis` test in `src/lib.rs`. I couldn't quickly figure out why this happens. Thought that you might have some insights here?